### PR TITLE
fix(links): add missing contact links to cards and fix homepage service links (#11)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,7 +73,7 @@ export default function Home() {
                 Juntos podemos trabajar para que mejores en los diferentes aspectos que afectan al rendimiento deportivo mientras disfrutas del proceso.
               </p>
               <Link
-                href="/about"
+                href="/methodology"
                 >
                 <button className="font-semibold relative flex h-[50px] w-40 items-center justify-center rounded-md overflow-hidden bg-primary-dark text-white shadow-2xl transition-all duration-300 before:absolute before:inset-0 before:border-0 before:border-secondary before:duration-100 before:ease-linear hover:bg-secondary hover:text-primary-dark hover:shadow-secondary hover:before:border-[25px]">
                   <span className="relative z-10">
@@ -160,7 +160,7 @@ export default function Home() {
                 Mejora tu rendimiento deportivo y salud mental con sesiones online personalizadas.
               </p>
               <Link 
-                href="/about"
+                href="/methodology"
                 className="bg-primary-dark text-white px-6 py-2 rounded-md hover:bg-secondary transition-colors mt-auto"
               >
                 Sesiones individuales
@@ -183,7 +183,7 @@ export default function Home() {
                 Mejora el rendimiento deportivo y la salud mental de los entrenadores o atletas de tu club con talleres grupales.
               </p>
               <Link 
-                href="/about"
+                href="/methodology"
                 className="bg-primary-dark text-white px-6 py-2 rounded-md hover:bg-secondary transition-colors mt-auto"
               >
                 Talleres grupales
@@ -206,7 +206,7 @@ export default function Home() {
                 Mejora el rendimiento deportivo y la salud mental de los entrenadores o atletas de tu club con un asesoramiento personalizado.
               </p>
               <Link 
-                href="/about"
+                href="/methodology"
                 className="bg-primary-dark text-white px-6 py-2 rounded-md hover:bg-secondary transition-colors mt-auto"
               >
                 Asesoramiento

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -99,7 +99,7 @@ export const methodologyCards: BaseCardProps[] = [
     Icon: LaptopIcon,
     description:
       "Sesiones personalizadas adaptadas a las características y requisitos particulares de cada atleta y su deporte.",
-    link: "contact",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/group-workshop.webp`,
@@ -107,7 +107,7 @@ export const methodologyCards: BaseCardProps[] = [
     Icon: UsersIcon,
     description:
       "Diseñados para fomentar el aprendizaje colaborativo y fortalecer las habilidades interpersonales.",
-    link: "contact",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/club-consulting.webp`,
@@ -127,6 +127,7 @@ export const performanceCards: BaseCardProps[] = [
     Icon: HeartbeatIcon,
     description:
       "A la hora de competir siempre vas a tener que lidiar con muchas emociones. La gestión que hagas de las diferentes emociones que aparezcan marcarán en gran parte tus resultados.",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/concentration.webp`,
@@ -134,6 +135,7 @@ export const performanceCards: BaseCardProps[] = [
     Icon: BrainIcon,
     description:
       "La concentración es esencial para el rendimiento deportivo, ya que te permitirá enfocarte en el presente, bloquear distracciones y ejecutar habilidades con precisión.",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/self-confidence.webp`,
@@ -141,6 +143,7 @@ export const performanceCards: BaseCardProps[] = [
     Icon: ChartlineIcon,
     description:
       "La autoconfianza es un pilar fundamental en el rendimiento deportivo, ya que influye directamente en tu capacidad para enfrentar desafíos y mantener la motivación.",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/motivation.webp`,
@@ -148,6 +151,7 @@ export const performanceCards: BaseCardProps[] = [
     Icon: LightbulbIcon,
     description:
       "La motivación es el motor esencial en el rendimiento deportivo, ya que te impulsa a fijarte metas, perseverar en el entrenamiento y superar desafíos.",
+    link: "/contact",
   },
   // Easy to add more social media here
 ];
@@ -159,6 +163,7 @@ export const mentalCards: BaseCardProps[] = [
     Icon: HeartIcon,
     description:
       "La gestión emocional es fundamental para la salud mental, ya que te permite comprender, regular y expresar las emociones de manera adecuada, promoviendo el equilibrio psicológico.",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/stress-management.webp`,
@@ -166,6 +171,7 @@ export const mentalCards: BaseCardProps[] = [
     Icon: BalanceIcon,
     description:
       "El manejo del estrés es crucial para preservar la salud mental, ya que el estrés crónico puede desencadenar problemas como ansiedad, depresión y agotamiento emocional.",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/burnout-prevention.webp`,
@@ -173,6 +179,7 @@ export const mentalCards: BaseCardProps[] = [
     Icon: BatteryIcon,
     description:
       "La prevención del burnout es esencial para proteger tu salud mental, ya que este síndrome afecta la capacidad de una persona para desempeñarse en su vida diaria y laboral.",
+    link: "/contact",
   },
   {
     image: `${baseUrl}/stock/self-esteem.webp`,
@@ -180,6 +187,7 @@ export const mentalCards: BaseCardProps[] = [
     Icon: StarIcon,
     description:
       "La autoestima es un componente esencial para la salud mental, ya que influye directamente en la forma en que te percibes a ti mismo y enfrentas los retos de la vida.",
+    link: "/contact",
   },
   // Easy to add more social media here
 ];


### PR DESCRIPTION
## What changed

This PR fixes broken or missing navigation links across the site so users can actually reach the contact page from cards and buttons.

### BaseCard links
- Added `link: "/contact"` to all 4 `performanceCards` in `src/utils/data.ts`
- Added `link: "/contact"` to all 4 `mentalCards` in `src/utils/data.ts`
- The `BaseCard` component only renders the "¡Pide Información!" button when a `link` prop is present. Previously these cards had no link, so the button was invisible.

### Methodology cards consistency
- Unified `methodologyCards` links: the first two used `"contact"` (relative, no leading slash) while the third used `"/contact"` (absolute). All three now use `"/contact"`.

### Homepage service section
- The three service cards at the bottom of the homepage (Sesiones individuales, Talleres grupales, Asesoramientos) were linking to `/about`. Changed to `/methodology`, which is the page that actually describes these services.

### Files changed
- `src/utils/data.ts`
- `src/app/page.tsx`

Closes #11