### PR TITLE
feat(contact): add Calendly booking block

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm install
 3. Create a `.env` file with the following variables:
 ```
 RESEND_API_KEY=your_resend_api_key
+NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-handle/your-event
 ```
 
 ## 🏃‍♂️ Development

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,6 +5,7 @@ import SocialCard from "@/components/containers/SocialCard";
 import { socialMediaLinks } from "@/utils/data";
 import SectionContainer from "@/components/containers/SectionContainer";
 import ContactForm from "@/components/core/Forms/ContactForm";
+import CalendlyBookingCard from "@/components/core/CalendlyBookingCard";
 
 export default function ContactPage() {
   return (
@@ -27,9 +28,19 @@ export default function ContactPage() {
 
         {/* Contact Form */}
         <SectionContainer className="bg-background-alt/50">
-          <div className="max-w-3xl mx-auto">
-            <div className="bg-background rounded-3xl shadow-card p-8 sm:p-12">
-              <ContactForm />
+          <div className="max-w-7xl mx-auto">
+            <div className="grid xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] gap-8 items-start">
+              <div className="bg-background rounded-3xl shadow-card p-8 sm:p-12">
+                <span className="text-secondary text-sm font-semibold uppercase tracking-widest">Formulario</span>
+                <h2 className="text-3xl font-bold text-text-dark mt-3 mb-4 tracking-tight">
+                  Cuentame tu caso
+                </h2>
+                <p className="text-text-light mb-8 leading-relaxed">
+                  Si prefieres explicarme primero tu situacion, completa el formulario y te respondere personalmente.
+                </p>
+                <ContactForm />
+              </div>
+              <CalendlyBookingCard />
             </div>
           </div>
         </SectionContainer>

--- a/src/components/core/CalendlyBookingCard.tsx
+++ b/src/components/core/CalendlyBookingCard.tsx
@@ -1,0 +1,41 @@
+const calendlyUrl = process.env.NEXT_PUBLIC_CALENDLY_URL;
+
+const CalendlyBookingCard = () => {
+  const hasCalendly = Boolean(calendlyUrl);
+
+  return (
+    <div className="bg-background rounded-3xl shadow-card p-8 sm:p-10 h-full flex flex-col">
+      <span className="text-secondary text-sm font-semibold uppercase tracking-widest">
+        Reserva directa
+      </span>
+      <h2 className="text-3xl font-bold text-text-dark mt-3 tracking-tight">
+        Reserva una llamada
+      </h2>
+      <p className="text-text mt-4 leading-relaxed">
+        Si prefieres elegir hora directamente, puedes reservar una cita desde el calendario.
+      </p>
+
+      {hasCalendly ? (
+        <div className="mt-8 rounded-2xl overflow-hidden border border-secondary/20 bg-background-alt/60 min-h-[720px]">
+          <iframe
+            src={calendlyUrl}
+            title="Calendly booking"
+            className="w-full h-[720px]"
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <div className="mt-8 rounded-2xl border border-dashed border-secondary/30 bg-background-alt/60 p-8 flex flex-col justify-center items-start gap-4 min-h-[320px]">
+          <p className="text-text leading-relaxed">
+            El bloque de reserva estara disponible en cuanto se configure la URL publica de Calendly.
+          </p>
+          <p className="text-text-light text-sm leading-relaxed">
+            Configuracion requerida: <code>NEXT_PUBLIC_CALENDLY_URL</code>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalendlyBookingCard;


### PR DESCRIPTION
## Summary
- add a Calendly booking block alongside the existing contact form
- make the booking integration configurable via NEXT_PUBLIC_CALENDLY_URL
- preserve a safe fallback UI when Calendly is not configured

Closes #17