### PR TITLE
fix: Calendly widget not showing due to client env parsing issue

### DIFF
--- a/src/components/core/CalendlyBookingCard.tsx
+++ b/src/components/core/CalendlyBookingCard.tsx
@@ -22,6 +22,8 @@ const CalendlyBookingCard = () => {
             title="Calendly booking"
             className="w-full h-[720px]"
             loading="lazy"
+            allow="camera; microphone; autoplay; fullscreen; display-capture"
+            referrerPolicy="no-referrer-when-downgrade"
           />
         </div>
       ) : (

--- a/src/config/client-env.config.ts
+++ b/src/config/client-env.config.ts
@@ -14,7 +14,9 @@ const clientEnvSchema = z.object({
     .transform((val) => val?.trim() || undefined),
 });
 
-const parsed = clientEnvSchema.safeParse(process.env);
+const parsed = clientEnvSchema.safeParse({
+  NEXT_PUBLIC_CALENDLY_URL: process.env.NEXT_PUBLIC_CALENDLY_URL,
+});
 
 if (!parsed.success) {
   const issues = parsed.error.issues


### PR DESCRIPTION
Root cause: Next.js bundler (Turbopack) cannot statically analyze process.env when passed as a whole object to zod.safeParse(), so NEXT_PUBLIC_CALENDLY_URL was not inlined into the client bundle. This caused a hydration mismatch: SSR rendered the iframe, but the client rendered the fallback placeholder.

Fix: explicitly pass process.env.NEXT_PUBLIC_CALENDLY_URL in the object literal so the bundler can replace it at build time.

Also added allow and referrerPolicy iframe attributes for better Calendly embed compatibility (camera, microphone, fullscreen).