### PR TITLE
#33 Replace Hu-manity with Cookiebot and add Google Tag Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,8 @@ PORT=3000
 # Optional — if omitted, the booking widget shows a friendly placeholder.
 # Example: https://calendly.com/your-name/30min
 NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-name/30min
+
+# Google Tag Manager container ID.
+# Optional — if omitted, GTM tracking is disabled.
+# Example: GTM-XXXXXXX
+NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,7 +7,7 @@ import ClubCard from "@/components/containers/ClubCard";
 import { IconCardContainer } from "@/components/containers/IconContainer";
 import SectionContainer from "@/components/containers/SectionContainer";
 import MainLayout from "@/components/core/MainLayout";
-import { baseUrl, clubs } from "@/utils/data";
+import { clubs } from "@/utils/data";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Sobre Pere Barceló Lambea | Psicólogo deportivo",
@@ -23,7 +23,7 @@ export default function AboutPage() {
       {/* Hero Section */}
       <div className="relative h-[500px] rounded-none sm:rounded-3xl overflow-hidden mx-0 sm:mx-6 lg:mx-8 mt-0 sm:mt-6">
         <Image
-          src={`${baseUrl}/stock/personas-escuchando.webp`}
+          src={`/stock/personas-escuchando.webp`}
           alt="Pere Barceló Lambea"
           fill
           priority
@@ -48,7 +48,7 @@ export default function AboutPage() {
             <div className="lg:w-1/2 w-full">
               <div className="relative h-[450px] lg:h-[550px] rounded-3xl overflow-hidden shadow-2xl">
                 <Image
-                  src={`${baseUrl}/profile/pere2-transparente.webp`}
+                  src={`/profile/pere2-transparente.webp`}
                   alt="Pere Barceló"
                   fill
                   sizes="(max-width: 1024px) 100vw, 50vw"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Script from "next/script";
+import { clientEnv } from "@/config/client-env.config";
 import { defaultMetadata } from "./metadata";
 import { Providers } from "./providers";
 
@@ -29,28 +30,31 @@ export const viewport: Viewport = {
   ],
 };
 
-const PrivacySettings = () => (
-  <>
-    <Script
-      id="humanity-options"
-      strategy="afterInteractive"
-      dangerouslySetInnerHTML={{
-        __html: `
-          var huOptions = {
-            'appID': 'perebarcelopsicologocom-5e860ea',
-            'currentLanguage': 'en',
-            'blocking': true,
-            'globalCookie': false
-          }
-        `,
-      }}
-    />
-    <Script
-      id="humanity-banner"
-      src="https://cdn.hu-manity.co/hu-banner.min.js"
-      strategy="afterInteractive"
-    />
-  </>
+const GTMHead = ({ gtmId }: { gtmId: string }) => (
+  <Script
+    id="gtm-script"
+    strategy="afterInteractive"
+    dangerouslySetInnerHTML={{
+      __html: `
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${gtmId}');
+      `,
+    }}
+  />
+);
+
+const GTMBody = ({ gtmId }: { gtmId: string }) => (
+  <noscript
+    dangerouslySetInnerHTML={{
+      __html: `
+        <iframe src="https://www.googletagmanager.com/ns.html?id=${gtmId}"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      `,
+    }}
+  />
 );
 
 export default function RootLayout({
@@ -58,10 +62,13 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const gtmId = clientEnv.NEXT_PUBLIC_GTM_ID;
+
   return (
     <html lang="es" suppressHydrationWarning className="scroll-smooth">
       <head>
-        <PrivacySettings />
+        {gtmId && <GTMHead gtmId={gtmId} />}
+
         {/* Preconnect to external domains */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -83,6 +90,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-white dark:bg-gray-900 font-sans antialiased`}
       >
+        {gtmId && <GTMBody gtmId={gtmId} />}
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/mental/page.tsx
+++ b/src/app/mental/page.tsx
@@ -7,7 +7,7 @@ import BaseCard from "@/components/containers/BaseCard";
 import SectionContainer from "@/components/containers/SectionContainer";
 import MainLayout from "@/components/core/MainLayout";
 import type { BaseCardProps } from "@/types/navbar";
-import { baseUrl, mentalCards } from "@/utils/data";
+import { mentalCards } from "@/utils/data";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Salud mental en el deporte | Pere Barceló",
@@ -23,7 +23,7 @@ export default function MentalHealthPage() {
       {/* Hero Section */}
       <header className="relative h-[500px] rounded-none sm:rounded-3xl overflow-hidden mx-0 sm:mx-6 lg:mx-8 mt-0 sm:mt-6">
         <Image
-          src={`${baseUrl}/stock/mental-health-hero.webp`}
+          src={`/stock/mental-health-hero.webp`}
           alt="Salud Mental"
           fill
           sizes="100vw"

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -7,7 +7,7 @@ import BaseCard from "@/components/containers/BaseCard";
 import SectionContainer from "@/components/containers/SectionContainer";
 import MainLayout from "@/components/core/MainLayout";
 import type { BaseCardProps } from "@/types/navbar";
-import { baseUrl, methodologyCards } from "@/utils/data";
+import { methodologyCards } from "@/utils/data";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Metodologia y modo de trabajo | Pere Barceló",
@@ -23,7 +23,7 @@ export default function WorkMethodPage() {
       {/* Hero Section */}
       <div className="relative h-[500px] rounded-none sm:rounded-3xl overflow-hidden mx-0 sm:mx-6 lg:mx-8 mt-0 sm:mt-6">
         <Image
-          src={`${baseUrl}/stock/sports-psychology.webp`}
+          src={`/stock/sports-psychology.webp`}
           alt="Psicología deportiva"
           fill
           sizes="100vw"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import { createPageMetadata } from "@/app/metadata";
 import { ScrollIcon } from "@/components/composables/Icons";
 import SectionContainer from "@/components/containers/SectionContainer";
 import MainLayout from "@/components/core/MainLayout";
-import { baseUrl } from "@/utils/data";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Psicólogo deportivo en Mallorca | Pere Barceló",
@@ -23,7 +22,7 @@ export default function Home() {
       <section className="relative h-screen min-h-[600px] w-full overflow-hidden">
         <div className="absolute inset-0">
           <Image
-            src={`${baseUrl}/stock/alcanza-tu-objetivo.webp`}
+            src={`/stock/alcanza-tu-objetivo.webp`}
             alt="Pista de atletismo"
             fill
             sizes="100vw"
@@ -73,7 +72,7 @@ export default function Home() {
           <div className="flex flex-col lg:flex-row items-center gap-12 lg:gap-16">
             <div className="relative w-full lg:w-1/2 h-[450px] lg:h-[500px] rounded-3xl overflow-hidden shadow-2xl">
               <Image
-                src={`${baseUrl}/profile/pere1-transparente.webp`}
+                src={`/profile/pere1-transparente.webp`}
                 alt="Pere Barceló Psicólogo Deportivo"
                 fill
                 sizes="(max-width: 1024px) 100vw, 50vw"
@@ -118,7 +117,7 @@ export default function Home() {
             <Link href="/performance" className="group block">
               <div className="relative h-80 rounded-3xl overflow-hidden shadow-card hover:shadow-card-hover transition-all duration-500 ease-smooth hover:-translate-y-2">
                 <Image
-                  src={`${baseUrl}/stock/golf-coaching.webp`}
+                  src={`/stock/golf-coaching.webp`}
                   alt="Entrenamiento de golf"
                   fill
                   sizes="(max-width: 768px) 100vw, 50vw"
@@ -138,7 +137,7 @@ export default function Home() {
             <Link href="/mental" className="group block">
               <div className="relative h-80 rounded-3xl overflow-hidden shadow-card hover:shadow-card-hover transition-all duration-500 ease-smooth hover:-translate-y-2">
                 <Image
-                  src={`${baseUrl}/stock/mental-health.webp`}
+                  src={`/stock/mental-health.webp`}
                   alt="Salud mental"
                   fill
                   sizes="(max-width: 768px) 100vw, 50vw"
@@ -172,7 +171,7 @@ export default function Home() {
             <div className="group flex flex-col items-center text-center">
               <div className="relative w-full aspect-square mb-6 rounded-3xl overflow-hidden shadow-card hover:shadow-card-hover transition-all duration-500 ease-smooth hover:-translate-y-2">
                 <Image
-                  src={`${baseUrl}/stock/sesiones-individuales.webp`}
+                  src={`/stock/sesiones-individuales.webp`}
                   alt="Sesiones individuales online"
                   fill
                   sizes="(max-width: 768px) 100vw, 33vw"
@@ -195,7 +194,7 @@ export default function Home() {
             <div className="group flex flex-col items-center text-center">
               <div className="relative w-full aspect-square mb-6 rounded-3xl overflow-hidden shadow-card hover:shadow-card-hover transition-all duration-500 ease-smooth hover:-translate-y-2">
                 <Image
-                  src={`${baseUrl}/stock/talleres-grupales.webp`}
+                  src={`/stock/talleres-grupales.webp`}
                   alt="Talleres grupales"
                   fill
                   sizes="(max-width: 768px) 100vw, 33vw"
@@ -219,7 +218,7 @@ export default function Home() {
             <div className="group flex flex-col items-center text-center">
               <div className="relative w-full aspect-square mb-6 rounded-3xl overflow-hidden shadow-card hover:shadow-card-hover transition-all duration-500 ease-smooth hover:-translate-y-2">
                 <Image
-                  src={`${baseUrl}/stock/asesoramientos-futbol.webp`}
+                  src={`/stock/asesoramientos-futbol.webp`}
                   alt="Asesoramiento deportivo"
                   fill
                   sizes="(max-width: 768px) 100vw, 33vw"

--- a/src/app/performance/page.tsx
+++ b/src/app/performance/page.tsx
@@ -7,7 +7,7 @@ import BaseCard from "@/components/containers/BaseCard";
 import SectionContainer from "@/components/containers/SectionContainer";
 import MainLayout from "@/components/core/MainLayout";
 import type { BaseCardProps } from "@/types/navbar";
-import { baseUrl, performanceCards } from "@/utils/data";
+import { performanceCards } from "@/utils/data";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Mejora tu rendimiento deportivo | Pere Barceló",
@@ -23,7 +23,7 @@ export default function PerformancePage() {
       {/* Hero Section */}
       <header className="relative h-[500px] rounded-none sm:rounded-3xl overflow-hidden mx-0 sm:mx-6 lg:mx-8 mt-0 sm:mt-6">
         <Image
-          src={`${baseUrl}/stock/performance-hero.webp`}
+          src={`/stock/performance-hero.webp`}
           alt="Rendimiento deportivo"
           fill
           sizes="100vw"

--- a/src/config/client-env.config.ts
+++ b/src/config/client-env.config.ts
@@ -12,10 +12,16 @@ const clientEnvSchema = z.object({
     .string()
     .optional()
     .transform((val) => val?.trim() || undefined),
+
+  NEXT_PUBLIC_GTM_ID: z
+    .string()
+    .optional()
+    .transform((val) => val?.trim() || undefined),
 });
 
 const parsed = clientEnvSchema.safeParse({
   NEXT_PUBLIC_CALENDLY_URL: process.env.NEXT_PUBLIC_CALENDLY_URL,
+  NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID,
 });
 
 if (!parsed.success) {


### PR DESCRIPTION
Closes #33

## What this does

Removes the Hu-manity cookie consent banner and replaces it with Google Tag Manager integration. GTM will be the single hub for all tracking tags (Cookiebot, GA4, Google Ads). The GTM snippet only loads when NEXT_PUBLIC_GTM_ID is set.

**Changes:**
- Removed Hu-manity PrivacySettings component from src/app/layout.tsx
- Added GTM head script and noscript fallback (conditional on NEXT_PUBLIC_GTM_ID)
- Added NEXT_PUBLIC_GTM_ID to client env validation (src/config/client-env.config.ts)
- Updated .env.example with NEXT_PUBLIC_GTM_ID placeholder
- Fixed remaining baseUrl imports in all page files (about, page, performance, methodology, mental)

**Requires account setup (HITL):**
1. Create Google Tag Manager account at tagmanager.google.com
2. Get GTM container ID (GTM-XXXXXXX format)
3. Add the ID to your environment variables (NEXT_PUBLIC_GTM_ID)
4. Configure Cookiebot in GTM via the Community Template Gallery
5. Set up Consent Mode v2 in GTM

## Acceptance criteria

- [x] Hu-manity PrivacySettings component fully removed from layout.tsx
- [x] GTM script present in <head> with correct container ID (when env var is set)
- [x] GTM noscript fallback present after <body> opening tag (when env var is set)
- [x] No tracking scripts fire when NEXT_PUBLIC_GTM_ID is not set
- [x] NEXT_PUBLIC_GTM_ID added to client env config and .env.example
- [x] All baseUrl references removed from pages
- [x] Site builds and runs without errors
- [x] Linter and type checker pass

## Blocked by

None - can start immediately (but needs GTM container ID from site owner)