### PR TITLE
feat: Redesign navbar and footer with cinematic dark style

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,10 +24,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   maximumScale: 5,
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
-  ],
+  themeColor: "#070b14",
 };
 
 const GTMHead = ({ gtmId }: { gtmId: string }) => (
@@ -88,7 +85,7 @@ export default function RootLayout({
         {/* <link rel="preload" href="/stock/alcanza-tu-objetivo.webp" as="image" /> */}
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-white dark:bg-gray-900 font-sans antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-[#070b14] font-sans antialiased`}
       >
         {gtmId && <GTMBody gtmId={gtmId} />}
         <Providers>{children}</Providers>

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -1,100 +1,114 @@
-// components/Footer.tsx
 import Link from "next/link";
+
 import { email, navbarLinks, phone, socialMediaLinksFooter } from "@/utils/data";
 import { EnvelopeIcon, WhatsappIcon } from "../composables/Icons";
-import { IconFooterContainer } from "../containers/IconContainer";
-import QuickLinkFooter from "../containers/QuickLinkFooter";
-import SocialLinkFooter from "../containers/SocialLinkFooter";
 
 const Footer = () => {
   return (
-    <footer className="bg-background-footer border-t border-white/5">
-      {/* Main Footer Content */}
-      <div className="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10">
-          {/* Brand Section */}
-          <div className="space-y-5">
-            <h3 className="text-xl font-bold text-white tracking-tight">
-              Pere Barceló
-              <span className="text-secondary">.</span>
-            </h3>
-            <p className="text-white/75 text-sm leading-relaxed">
-              Psicólogo deportivo especializado en mejorar el rendimiento y la salud mental de
-              deportistas a través de sesiones online, talleres y asesoramiento.
+    <footer className="relative bg-[#050810] overflow-hidden">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_50%,_rgba(245,158,11,0.04)_0%,_transparent_60%)]" />
+
+      <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 pt-16 pb-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-12 lg:gap-8">
+          <div className="lg:col-span-5">
+            <Link
+              href="/"
+              className="inline-block text-white font-bold text-xl tracking-tight hover:text-secondary transition-colors duration-300"
+            >
+              Pere Barcelo
+              <span className="font-normal text-white/40 ml-1.5 text-lg">Psicologo</span>
+            </Link>
+            <p className="mt-4 text-white/40 leading-relaxed max-w-sm">
+              Psicologo deportivo especializado en mejorar el rendimiento y la salud mental de
+              deportistas a traves de sesiones online, talleres y asesoramiento.
             </p>
+
+            <div className="mt-6 flex items-center gap-4">
+              <a
+                href={`mailto:${email}`}
+                className="flex items-center gap-2 text-white/40 hover:text-secondary transition-colors duration-300 text-sm"
+              >
+                <EnvelopeIcon className="w-4 h-4" />
+                <span>{email}</span>
+              </a>
+            </div>
+            <div className="mt-2 flex items-center gap-4">
+              <a
+                href={`tel:${phone}`}
+                className="flex items-center gap-2 text-white/40 hover:text-secondary transition-colors duration-300 text-sm"
+              >
+                <WhatsappIcon className="w-4 h-4" />
+                <span>{phone}</span>
+              </a>
+            </div>
+
+            <div className="mt-6 flex items-center gap-3">
+              {socialMediaLinksFooter.map((social) => {
+                const Icon = social.Icon;
+                return (
+                  <a
+                    key={social.name}
+                    href={social.link}
+                    target={social.link.startsWith("mailto") ? undefined : "_blank"}
+                    rel={social.link.startsWith("mailto") ? undefined : "noopener noreferrer"}
+                    className="w-10 h-10 rounded-xl bg-white/[0.04] border border-white/[0.06] flex items-center justify-center
+                             hover:bg-secondary/10 hover:border-secondary/20 hover:text-secondary
+                             text-white/40 transition-all duration-300"
+                    aria-label={social.name}
+                  >
+                    <Icon className="w-4 h-4" />
+                  </a>
+                );
+              })}
+            </div>
           </div>
 
-          {/* Quick Links */}
-          <div>
-            <h3 className="text-sm font-semibold text-white uppercase tracking-wider mb-5">
-              Enlaces rápidos
+          <div className="lg:col-span-3">
+            <h3 className="text-xs font-bold text-secondary uppercase tracking-[0.2em] mb-5">
+              Navegacion
             </h3>
-            <ul className="space-y-3 text-sm">
+            <ul className="space-y-3">
               {navbarLinks.map((link) => (
                 <li key={link.url}>
-                  <QuickLinkFooter link={link} />
+                  <Link
+                    href={link.url}
+                    className="text-white/40 hover:text-white text-sm transition-colors duration-300"
+                  >
+                    {link.label}
+                  </Link>
                 </li>
               ))}
             </ul>
           </div>
 
-          {/* Contact Info */}
-          <div>
-            <h3 className="text-sm font-semibold text-white uppercase tracking-wider mb-5">
-              Contacto
+          <div className="lg:col-span-4">
+            <h3 className="text-xs font-bold text-secondary uppercase tracking-[0.2em] mb-5">
+              Empieza hoy
             </h3>
-            <div className="space-y-4 text-sm">
-              <div className="flex items-center space-x-3 group">
-                <IconFooterContainer>
-                  <EnvelopeIcon className="w-5 h-5 text-white" />
-                </IconFooterContainer>
-                <a
-                  href={`mailto:${email}`}
-                  className="text-white/80 hover:text-white transition-colors duration-300"
-                >
-                  {email}
-                </a>
-              </div>
-              <div className="flex items-center space-x-3 group">
-                <IconFooterContainer>
-                  <WhatsappIcon className="w-5 h-5 text-white" />
-                </IconFooterContainer>
-                <a
-                  href={`tel:${phone}`}
-                  className="text-white/80 hover:text-white transition-colors duration-300"
-                >
-                  {phone}
-                </a>
-              </div>
-            </div>
-          </div>
-
-          {/* Social Links */}
-          <div>
-            <h3 className="text-sm font-semibold text-white uppercase tracking-wider mb-5">
-              Sígueme
-            </h3>
-            <div className="flex space-x-3">
-              {socialMediaLinksFooter.map((social) => (
-                <SocialLinkFooter key={social.name} social={social} />
-              ))}
-            </div>
+            <p className="text-white/40 text-sm leading-relaxed mb-6">
+              La primera sesion es gratuita. Si sabes que puedes rendir mas, hablemos.
+            </p>
+            <Link
+              href="/contact"
+              className="inline-flex items-center justify-center bg-secondary text-[#0f172a] text-sm font-bold px-6 py-3 rounded-full hover:bg-secondary-light hover:shadow-[0_0_25px_rgba(245,158,11,0.3)] hover:-translate-y-0.5 transition-all duration-300"
+            >
+              Reserva tu sesion gratuita
+            </Link>
           </div>
         </div>
 
-        {/* Bottom Bar */}
-        <div className="mt-16 pt-8 border-t border-white/10">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-            <p className="text-white/65 text-sm">
-              &copy; {new Date().getFullYear()} Pere Barceló Psicólogo. Todos los derechos
+        <div className="mt-16 pt-8 border-t border-white/[0.06]">
+          <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+            <p className="text-white/25 text-xs">
+              &copy; {new Date().getFullYear()} Pere Barcelo Psicologo. Todos los derechos
               reservados.
             </p>
-            <div className="flex space-x-6">
+            <div className="flex items-center gap-6">
               <Link
                 href="/privacy"
-                className="text-white/80 hover:text-white text-sm transition-colors duration-300"
+                className="text-white/25 hover:text-white/50 text-xs transition-colors duration-300"
               >
-                Política de Privacidad
+                Politica de Privacidad
               </Link>
             </div>
           </div>

--- a/src/components/core/MainLayout.tsx
+++ b/src/components/core/MainLayout.tsx
@@ -9,7 +9,7 @@ const MainLayout = ({ children }: Props) => {
   return (
     <>
       <Navbar />
-      <div className="flex flex-col min-h-screen flex-grow bg-primary">{children}</div>
+      <div className="flex flex-col min-h-screen flex-grow">{children}</div>
       <Footer />
     </>
   );

--- a/src/components/core/NavBar.tsx
+++ b/src/components/core/NavBar.tsx
@@ -1,122 +1,175 @@
 "use client";
-import Link from "next/link";
-import { useState } from "react";
-import { ThemeToggle } from "@/components/features/DarkToggle";
-import { navbarLinks } from "@/utils/data";
 
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { navbarLinks } from "@/utils/data";
 import { BarsIcon, CrossIcon } from "../composables/Icons";
-import { IconFooterContainer } from "../containers/IconContainer";
 
 const Navbar = () => {
-  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    setIsScrolled(window.scrollY > 20);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isMenuOpen]);
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-background-navbar backdrop-blur-xl border-b border-white/10">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-20">
-          <div className="flex justify-center space-x-4">
-            {/* Logo/Brand */}
+    <>
+      <nav
+        className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ${
+          isScrolled
+            ? "bg-[#070b14]/95 backdrop-blur-xl border-b border-white/[0.06] shadow-[0_4px_30px_rgba(0,0,0,0.3)]"
+            : "bg-transparent"
+        }`}
+      >
+        <div className="max-w-7xl mx-auto px-5 sm:px-8 lg:px-12">
+          <div className="flex justify-between items-center h-20">
             <Link
               href="/"
-              className="content-center text-white font-bold text-lg tracking-tight whitespace-nowrap hover:text-secondary transition-colors duration-300"
+              className="text-white font-bold text-lg tracking-tight whitespace-nowrap hover:text-secondary transition-colors duration-300"
             >
-              Pere Barceló
-              <span className="font-normal text-white/70 ml-1">Psicólogo</span>
+              Pere Barcelo
+              <span className="font-normal text-white/50 ml-1.5 text-base">Psicologo</span>
             </Link>
-          </div>
 
-          {/* Navigation Links */}
-          <div className="hidden lg:flex items-center space-x-2">
-            {navbarLinks.map((item) => (
-              <div className="relative group" key={item.url}>
-                <Link
-                  href={item.url}
-                  className="text-white/80 whitespace-nowrap px-3 py-2 text-sm font-medium tracking-[0.01em]
-                           border-b-2 border-transparent hover:border-secondary hover:text-white
-                           transition-colors duration-200"
-                >
-                  {item.label}
-                </Link>
-
-                {/* Dropdown Menu */}
-                {item.subLinks && (
-                  <div
-                    className="absolute invisible group-hover:visible opacity-0 
-                                group-hover:opacity-100 left-0 pt-2 w-60 
-                                transition-all duration-300 ease-smooth"
+            <div className="hidden lg:flex items-center gap-1">
+              {navbarLinks.map((item) => (
+                <div className="relative group" key={item.url}>
+                  <Link
+                    href={item.url}
+                    className="text-white/70 px-4 py-2 text-sm font-medium tracking-wide
+                             hover:text-white hover:bg-white/[0.06] rounded-lg
+                             transition-all duration-300"
                   >
-                    <div className="bg-background-navbar/95 backdrop-blur-2xl rounded-2xl shadow-[0_24px_60px_rgba(2,6,23,0.38)] border border-white/20 overflow-hidden ring-1 ring-white/10 p-2">
-                      {item.subLinks.map((subLink) => (
-                        <Link
-                          key={subLink.url}
-                          href={subLink.url}
-                          className="block px-4 py-3 rounded-xl text-sm font-semibold text-white/92 whitespace-nowrap
-                                   hover:bg-white/14 hover:text-white hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]
-                                   transition-all duration-200"
-                        >
-                          {subLink.label}
-                        </Link>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+                    {item.label}
+                  </Link>
 
-          <div className="flex flex-row items-center gap-3">
-            {/* Mobile Menu Button */}
-            <div className="lg:hidden">
+                  {item.subLinks && (
+                    <div
+                      className="absolute invisible group-hover:visible opacity-0
+                                  group-hover:opacity-100 left-0 pt-2 w-60
+                                  transition-all duration-300"
+                    >
+                      <div className="bg-[#0f172a]/95 backdrop-blur-2xl rounded-2xl shadow-[0_24px_60px_rgba(0,0,0,0.5)] border border-white/[0.08] overflow-hidden p-2">
+                        {item.subLinks.map((subLink) => (
+                          <Link
+                            key={subLink.url}
+                            href={subLink.url}
+                            className="block px-4 py-3 rounded-xl text-sm font-medium text-white/70 whitespace-nowrap
+                                     hover:text-white hover:bg-white/[0.08]
+                                     transition-all duration-200"
+                          >
+                            {subLink.label}
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              <Link
+                href="/contact"
+                className="ml-4 inline-flex items-center justify-center bg-secondary text-[#0f172a] text-sm font-bold px-5 py-2.5 rounded-full hover:bg-secondary-light hover:shadow-[0_0_20px_rgba(245,158,11,0.3)] hover:-translate-y-0.5 transition-all duration-300"
+              >
+                Sesion gratuita
+              </Link>
+            </div>
+
+            <div className="flex items-center gap-3 lg:hidden">
+              <Link
+                href="/contact"
+                className="inline-flex items-center justify-center bg-secondary text-[#0f172a] text-xs font-bold px-4 py-2 rounded-full hover:bg-secondary-light transition-all duration-300"
+              >
+                Sesiongratis
+              </Link>
+
               <button
                 type="button"
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
-                className="text-white hover:text-secondary p-2 rounded-full hover:bg-white/10 transition-all duration-300"
+                className="text-white hover:text-secondary p-2 rounded-xl hover:bg-white/[0.06] transition-all duration-300"
+                aria-label={isMenuOpen ? "Cerrar menu" : "Abrir menu"}
               >
                 {isMenuOpen ? <CrossIcon className="w-6 h-6" /> : <BarsIcon className="w-6 h-6" />}
               </button>
             </div>
-            <IconFooterContainer>
-              <ThemeToggle />
-            </IconFooterContainer>
           </div>
         </div>
+      </nav>
 
-        {/* Mobile Navigation */}
-        <div className={`lg:hidden ${isMenuOpen ? "block" : "hidden"}`}>
-          <div className="px-2 pb-4 space-y-1">
-            {navbarLinks.map((item) => (
-              <div key={item.url}>
-                <Link
-                  href={item.url}
-                  className="text-white/80 block px-4 py-3 text-base font-medium rounded-xl
-                           hover:text-white hover:bg-white/10 transition-all duration-300"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  {item.label}
-                </Link>
-
-                {/* Mobile Dropdown Items */}
-                {item.subLinks && (
-                  <div className="pl-4 space-y-1">
-                    {item.subLinks.map((subLink) => (
-                      <Link
-                        key={subLink.url}
-                        href={subLink.url}
-                        className="text-white/60 block px-4 py-2 text-sm font-medium rounded-xl
-                                 hover:text-secondary hover:bg-white/5 transition-all duration-300"
-                        onClick={() => setIsMenuOpen(false)}
-                      >
-                        {subLink.label}
-                      </Link>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
+      <div
+        className={`fixed inset-0 z-40 bg-[#070b14]/98 backdrop-blur-xl transition-all duration-500 lg:hidden ${
+          isMenuOpen ? "opacity-100 visible" : "opacity-0 invisible"
+        }`}
+      >
+        <div className="flex flex-col items-center justify-center min-h-screen gap-6">
+          <div className="absolute top-6 right-6">
+            <button
+              type="button"
+              onClick={() => setIsMenuOpen(false)}
+              className="text-white hover:text-secondary p-2 rounded-xl hover:bg-white/[0.06] transition-all duration-300"
+              aria-label="Cerrar menu"
+            >
+              <CrossIcon className="w-7 h-7" />
+            </button>
           </div>
+
+          {navbarLinks.map((item, index) => (
+            <div key={item.url}>
+              <Link
+                href={item.url}
+                onClick={() => setIsMenuOpen(false)}
+                className="text-2xl font-bold text-white/80 hover:text-white transition-all duration-300"
+                style={{ transitionDelay: `${(index + 1) * 50}ms` }}
+              >
+                {item.label}
+              </Link>
+
+              {item.subLinks && (
+                <div className="mt-3 space-y-2 text-center">
+                  {item.subLinks.map((subLink) => (
+                    <Link
+                      key={subLink.url}
+                      href={subLink.url}
+                      onClick={() => setIsMenuOpen(false)}
+                      className="block text-white/50 hover:text-secondary text-base transition-colors duration-200"
+                    >
+                      {subLink.label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+
+          <Link
+            href="/contact"
+            onClick={() => setIsMenuOpen(false)}
+            className="mt-4 inline-flex items-center justify-center bg-secondary text-[#0f172a] text-base font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-[0_0_30px_rgba(245,158,11,0.3)] transition-all duration-300"
+          >
+            Sesion gratuita
+          </Link>
         </div>
       </div>
-    </nav>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Apply the same dark, editorial design language to the header and footer to complete the site-wide redesign.

## Navbar

| Feature | Before | After |
|---|---|---|
| Background | Solid  always | Transparent on top, solid  + backdrop-blur on scroll |
| Transition | None | Smooth 500ms scroll-triggered with shadow |
| CTA | None | Amber "Sesion gratuita" button (desktop + mobile header) |
| Mobile menu | Slide-down panel | Full-screen overlay with centered links + CTA |
| Theme toggle | Present (sun/moon) | Removed (site is dark-first) |
| Border |  always |  on scroll only |

## Footer

| Feature | Before | After |
|---|---|---|
| Background |  |  with amber radial gradient accent |
| Layout | 4-column grid | 3-column: brand/social, nav, CTA |
| Labels | White uppercase | Amber accent uppercase (tracking-wider) |
| CTA | None | Amber "Reserva tu sesion gratuita" button with glow |
| Social icons | Round circles | Rounded squares with amber hover |
| Bottom bar | Dense | Minimal with privacy link |

## Layout changes

- Body bg:  ->  (no white flash on load)
- MainLayout: removed  class (pages control their own bg)
- Theme color: 

## Design decisions

1. **No more theme toggle** - The entire site uses dark-first design. The toggle was adding visual noise and the dark palette is the identity. Removed cleanly from NavBar; ThemeProvider still wraps app for future flexibility.
2. **Scroll-away navbar** - Transparent at top immerses the hero, then solidifies on scroll. Creates depth and avoids visual weight when reading content.
3. **Full-screen mobile menu** - Cinematic full-bleed overlay feels intentional rather than an afterthought dropdown.
4. **Footer CTA** - The footer now has a conversion moment ("Empieza hoy" section with amber button), not just information.

## Verification

- Build passes (`next build`)
- Lint passes (`biome check`)
- All pages render correctly with new header/footer
- All navigation links work across pages