### PR TITLE
feat: prioritize calendly booking on contact page

### DIFF
--- a/src/components/contact/ContactFormSection.tsx
+++ b/src/components/contact/ContactFormSection.tsx
@@ -3,33 +3,25 @@
 import AnimatedSection from "@/components/composables/AnimatedSection";
 import SectionLabel from "@/components/composables/SectionLabel";
 import CalendlyBookingCard from "@/components/core/CalendlyBookingCard";
-import ContactForm from "@/components/core/Forms/ContactForm";
 
 export default function ContactFormSection() {
   return (
     <section className="relative bg-[#070b14] overflow-hidden">
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_20%_50%,_rgba(245,158,11,0.04)_0%,_transparent_50%)]" />
 
-      <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
+      <div className="relative z-10 max-w-5xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <AnimatedSection className="text-center mb-16">
-          <SectionLabel text="Escribeme" />
+          <SectionLabel text="Reserva" />
           <h2 className="text-4xl sm:text-5xl font-bold text-white tracking-tight">
-            Cuentame tu caso
+            Agenda tu sesion gratuita
           </h2>
           <p className="mt-4 text-lg text-white/50 max-w-2xl mx-auto">
-            Rellena el formulario o reserva directamente una llamada. Sin compromiso.
+            Sin compromiso. Elige el dia y la hora que mejor te venga.
           </p>
         </AnimatedSection>
 
         <AnimatedSection>
-          <div className="grid xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] gap-8 items-start">
-            <div className="bg-[#f8fafc] rounded-3xl shadow-2xl shadow-black/20 p-8 sm:p-12">
-              <ContactForm />
-            </div>
-            <div className="bg-[#f8fafc] rounded-3xl shadow-2xl shadow-black/20 overflow-hidden">
-              <CalendlyBookingCard />
-            </div>
-          </div>
+          <CalendlyBookingCard />
         </AnimatedSection>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Make calendar booking the primary action on /contact. The form is removed temporarily pending client review (component preserved in codebase).

## Changes

- Removed  from the page (component kept, just not rendered)
-  is now full-width and centered as the main content
- Updated section heading from "Cuentame tu caso" to "Agenda tu sesion gratuita"
- Removed white card wrappers that caused invisible text in dark mode
- Simplified grid layout to single column

## Design decisions

1. **Calendar first** - The primary conversion goal is scheduling sessions, not sending messages. Calendly is now the hero content.
2. **Form preserved** - Still available to re-add after client feedback.
3. **No more white cards** - The  wrappers clashed with dark-mode CSS variables, causing invisible text. Calendly card uses its own dark backgrounds that work correctly.

## Verification

- [x] Build passes
- [x] Single file changed: ContactFormSection.tsx