### PR TITLE
feat: apply client feedback across all pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,21 +3,21 @@
 @tailwind utilities;
 
 :root {
-  --primary: #1c4761;
-  --primary-light: #d4e6f3;
-  --primary-dark: #1c4761;
+  --primary: #122f41;
+  --primary-light: #b9d8eb;
+  --primary-dark: #122f41;
 
   --background: #f8fafc;
   --background-alt: #ffffff;
   --background-navbar: rgba(248, 250, 252, 0.92);
-  --background-footer: #0f2537;
+  --background-footer: #122f41;
 
   --card: #ffffff;
   --card-hover: #f1f5f9;
 
-  --secondary-rgb: 245 158 11;
-  --secondary-light-rgb: 252 211 77;
-  --secondary-dark-rgb: 217 119 6;
+  --secondary-rgb: 185 216 235;
+  --secondary-light-rgb: 211 233 245;
+  --secondary-dark-rgb: 140 185 210;
 
   --text: #334155;
   --text-light: #64748b;
@@ -25,7 +25,7 @@
   --text-inverse: #ffffff;
 
   --border: #e2e8f0;
-  --glow: rgba(245, 158, 11, 0.3);
+  --glow: rgba(185, 216, 235, 0.3);
 
   --success: #22c55e;
   --warning: #f59e0b;
@@ -45,9 +45,9 @@
   --card: rgba(255, 255, 255, 0.03);
   --card-hover: rgba(255, 255, 255, 0.06);
 
-  --secondary-rgb: 245 158 11;
-  --secondary-light-rgb: 252 211 77;
-  --secondary-dark-rgb: 251 191 36;
+  --secondary-rgb: 185 216 235;
+  --secondary-light-rgb: 211 233 245;
+  --secondary-dark-rgb: 140 185 210;
 
   --text: #e2e8f0;
   --text-light: #94a3b8;
@@ -55,7 +55,7 @@
   --text-inverse: #ffffff;
 
   --border: rgba(255, 255, 255, 0.06);
-  --glow: rgba(245, 158, 11, 0.35);
+  --glow: rgba(185, 216, 235, 0.35);
 }
 
 html {
@@ -63,6 +63,6 @@ html {
 }
 
 ::selection {
-  background-color: rgba(245, 158, 11, 0.3);
+  background-color: rgba(185, 216, 235, 0.3);
   color: inherit;
 }

--- a/src/components/about/AboutBioSection.tsx
+++ b/src/components/about/AboutBioSection.tsx
@@ -5,13 +5,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 
-import SectionLabel from "@/components/composables/SectionLabel";
-
 export default function AboutBioSection() {
   const t = useTranslations("AboutBioSection");
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_20%_50%,_rgba(245,158,11,0.05)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_20%_50%,_rgba(185,216,235,0.05)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-12 gap-12 lg:gap-16 items-center">
@@ -28,7 +26,7 @@ export default function AboutBioSection() {
 
               <div className="relative aspect-[4/5] rounded-[2rem] overflow-hidden shadow-2xl">
                 <Image
-                  src="/wp/profile-photo.webp"
+                  src="/profile/pere1-transparente.webp"
                   alt={t("imageAlt")}
                   fill
                   sizes="(max-width: 1024px) 100vw, 45vw"
@@ -45,29 +43,24 @@ export default function AboutBioSection() {
             viewport={{ once: true }}
             transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1], delay: 0.15 }}
           >
-            <SectionLabel text={t("sectionLabel")} />
             <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight">
               {t("heading")}
             </h2>
 
             <div className="mt-8 space-y-5">
-              <p className="text-xl text-text-dark font-medium leading-relaxed">{t("bio1")}</p>
-              <p className="text-lg text-text-light leading-relaxed">{t("bio2")}</p>
-              <p className="text-lg text-text-light leading-relaxed">{t("bio3")}</p>
-            </div>
-
-            <p className="mt-6 text-lg text-text-dark font-medium">{t("emphasis")}</p>
-
-            <div className="mt-6 space-y-3">
-              <p className="text-lg text-text-light leading-relaxed">{t("paragraph")}</p>
-              <p className="text-lg text-text-dark font-bold leading-relaxed">{t("boldText")}</p>
-              <p className="text-lg text-text-dark font-bold leading-relaxed">{t("ctaText")}</p>
+              <p className="text-lg text-text leading-relaxed">{t("bio1")}</p>
+              <p className="text-lg text-text leading-relaxed">{t("bio2")}</p>
+              <p className="text-lg text-text leading-relaxed">{t("bio3")}</p>
+              <p className="text-lg text-text leading-relaxed font-bold">{t("emphasis")}</p>
+              <p className="text-lg text-text leading-relaxed">{t("paragraph")}</p>
+              <p className="text-lg text-text leading-relaxed font-bold">{t("boldText")}</p>
+              <p className="text-lg text-text leading-relaxed font-bold">{t("ctaText")}</p>
             </div>
 
             <div className="mt-8">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("cta")}
               </Link>

--- a/src/components/about/AboutClubsSection.tsx
+++ b/src/components/about/AboutClubsSection.tsx
@@ -13,7 +13,7 @@ export default function AboutClubsSection() {
   const t = useTranslations("AboutClubsSection");
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,_rgba(245,158,11,0.06)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <AnimatedSection className="text-center mb-16 max-w-3xl mx-auto">

--- a/src/components/about/AboutCtaSection.tsx
+++ b/src/components/about/AboutCtaSection.tsx
@@ -9,7 +9,7 @@ export default function AboutCtaSection() {
   const t = useTranslations("AboutCtaSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,_rgba(245,158,11,0.08)_0%,_transparent_70%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,_rgba(185,216,235,0.08)_0%,_transparent_70%)]" />
 
       <div className="relative z-10 max-w-4xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32 text-center">
         <AnimatedSection>
@@ -20,7 +20,7 @@ export default function AboutCtaSection() {
           <div className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
             >
               {t("cta")}
             </Link>

--- a/src/components/about/AboutExpectSection.tsx
+++ b/src/components/about/AboutExpectSection.tsx
@@ -37,7 +37,7 @@ export default function AboutExpectSection() {
               className="flex items-start gap-4 p-6 rounded-2xl bg-card border border-border hover:bg-card-hover hover:border-secondary/20 transition-all duration-300"
             >
               <div className="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center shrink-0">
-                <CheckIcon className="w-5 h-5 text-secondary" />
+                <CheckIcon className="w-5 h-5 text-primary" />
               </div>
               <p className="text-text-dark font-medium leading-relaxed">{text}</p>
             </motion.div>

--- a/src/components/about/AboutHeroSection.tsx
+++ b/src/components/about/AboutHeroSection.tsx
@@ -12,7 +12,7 @@ export default function AboutHeroSection() {
   const t = useTranslations("AboutHeroSection");
   return (
     <section className="relative min-h-[70vh] flex items-center overflow-hidden bg-background">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_30%,_rgba(245,158,11,0.08)_0%,_transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_30%,_rgba(185,216,235,0.08)_0%,_transparent_50%)]" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_70%,_rgba(28,71,97,0.25)_0%,_transparent_60%)]" />
 
       <div className="absolute top-0 right-[20%] w-px h-full bg-gradient-to-b from-transparent via-white/5 to-transparent" />
@@ -39,7 +39,7 @@ export default function AboutHeroSection() {
             <motion.div variants={fadeInUp} className="mt-10">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("cta")}
               </Link>
@@ -57,7 +57,7 @@ export default function AboutHeroSection() {
 
               <div className="relative aspect-[4/5] rounded-[2rem] overflow-hidden shadow-2xl shadow-black/40 border border-border">
                 <Image
-                  src="/wp/profile-photo.webp"
+                  src="/profile/pere1-transparente.webp"
                   alt={t("imageAlt")}
                   fill
                   sizes="(max-width: 768px) 80vw, 380px"

--- a/src/components/about/AboutObjectiveSection.tsx
+++ b/src/components/about/AboutObjectiveSection.tsx
@@ -40,7 +40,7 @@ export default function AboutObjectiveSection() {
                   <svg
                     role="img"
                     aria-label="Checkmark"
-                    className="w-4 h-4 text-secondary group-hover:text-text-dark transition-colors duration-300"
+                    className="w-4 h-4 text-primary group-hover:text-text-dark transition-colors duration-300"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"

--- a/src/components/about/AboutWhySection.tsx
+++ b/src/components/about/AboutWhySection.tsx
@@ -26,13 +26,11 @@ export default function AboutWhySection() {
               <p className="text-lg text-text leading-relaxed">{t("paragraph1")}</p>
               <p className="text-lg text-text leading-relaxed">{t("paragraph2")}</p>
               <p className="text-lg text-text leading-relaxed">{t("paragraph3")}</p>
-              <div className="mt-8 p-6 rounded-2xl bg-primary-dark text-text-inverse">
-                <p className="text-lg font-bold">{t("highlight")}</p>
-              </div>
+              <p className="text-lg text-text-dark font-bold leading-relaxed">{t("highlight")}</p>
               <div className="mt-8">
                 <a
                   href="/contact"
-                  className="inline-flex items-center justify-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
                 >
                   {t("cta")}
                 </a>

--- a/src/components/composables/SectionLabel.tsx
+++ b/src/components/composables/SectionLabel.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export default function SectionLabel({ text }: Props) {
   return (
-    <span className="inline-block text-secondary text-xs font-bold uppercase tracking-[0.2em] mb-4">
+    <span className="inline-block text-primary text-xs font-bold uppercase tracking-[0.2em] mb-4">
       {text}
     </span>
   );

--- a/src/components/contact/ContactFormSection.tsx
+++ b/src/components/contact/ContactFormSection.tsx
@@ -9,7 +9,7 @@ export default function ContactFormSection() {
   const t = useTranslations("ContactFormSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_20%_50%,_rgba(245,158,11,0.04)_0%,_transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_20%_50%,_rgba(185,216,235,0.04)_0%,_transparent_50%)]" />
 
       <div className="relative z-10 max-w-5xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <AnimatedSection className="text-center mb-16">

--- a/src/components/contact/ContactHeroSection.tsx
+++ b/src/components/contact/ContactHeroSection.tsx
@@ -10,7 +10,7 @@ export default function ContactHeroSection() {
   const t = useTranslations("ContactHeroSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(245,158,11,0.06)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
       <div className="absolute top-0 left-[30%] w-px h-full bg-gradient-to-b from-transparent via-white/5 to-transparent" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">

--- a/src/components/contact/ContactSocialSection.tsx
+++ b/src/components/contact/ContactSocialSection.tsx
@@ -19,7 +19,7 @@ export default function ContactSocialSection() {
   const t = useTranslations("ContactSocialSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_80%_50%,_rgba(245,158,11,0.04)_0%,_transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_80%_50%,_rgba(185,216,235,0.04)_0%,_transparent_50%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <AnimatedSection className="text-center mb-16">
@@ -49,11 +49,11 @@ export default function ContactSocialSection() {
               >
                 <div className="w-14 h-14 rounded-2xl bg-secondary/10 flex items-center justify-center mx-auto mb-6 group-hover:bg-secondary/15 transition-colors duration-300">
                   {IconComponent && (
-                    <IconComponent className="w-7 h-7 text-secondary transition-colors duration-300" />
+                    <IconComponent className="w-7 h-7 text-primary transition-colors duration-300" />
                   )}
                 </div>
                 <h3 className="text-text-dark font-bold text-lg">{social.name}</h3>
-                <span className="text-text-light group-hover:text-secondary transition-colors duration-300 text-sm mt-1 block">
+                <span className="text-text-light group-hover:text-primary transition-colors duration-300 text-sm mt-1 block">
                   {social.username}
                 </span>
               </motion.a>

--- a/src/components/core/CalendlyBookingCard.tsx
+++ b/src/components/core/CalendlyBookingCard.tsx
@@ -9,7 +9,7 @@ const CalendlyBookingCard = () => {
 
   return (
     <div className="bg-background rounded-3xl shadow-card p-8 sm:p-10 h-full flex flex-col">
-      <span className="text-secondary text-sm font-semibold uppercase tracking-widest">
+      <span className="text-primary text-sm font-semibold uppercase tracking-widest">
         {t("label")}
       </span>
       <h2 className="text-3xl font-bold text-text-dark mt-3 tracking-tight">{t("heading")}</h2>

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -20,7 +20,7 @@ const Footer = () => {
 
   return (
     <footer className="relative bg-background-footer overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_50%,_rgba(245,158,11,0.04)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_50%,_rgba(185,216,235,0.04)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 pt-16 pb-8">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-12 lg:gap-8">
@@ -108,7 +108,7 @@ const Footer = () => {
             </p>
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center bg-secondary text-text-dark text-sm font-bold px-6 py-3 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-sm font-bold px-6 py-3 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
             >
               {t("ctaButton")}
             </Link>

--- a/src/components/core/NavBar.tsx
+++ b/src/components/core/NavBar.tsx
@@ -8,12 +8,7 @@ import { usePathname, useRouter } from "@/i18n/routing";
 
 import { BarsIcon, CrossIcon } from "../composables/Icons";
 
-const navItems = [
-  { url: "/" },
-  { url: "/about" },
-  { url: "/servicios" },
-  { url: "/contact" },
-] as const;
+const navItems = [{ url: "/" }, { url: "/about" }, { url: "/servicios" }] as const;
 
 const Navbar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -28,7 +28,7 @@ export default function AboutSection() {
 
               <div className="relative aspect-[4/5] rounded-[2rem] overflow-hidden shadow-2xl">
                 <Image
-                  src="/wp/profile-photo.webp"
+                  src="/profile/pere1-transparente.webp"
                   alt={t("imageAlt")}
                   fill
                   sizes="(max-width: 1024px) 100vw, 45vw"
@@ -52,7 +52,7 @@ export default function AboutSection() {
             </h2>
 
             <div className="mt-8 space-y-5">
-              <p className="text-xl text-text-dark font-medium leading-relaxed">{t("bio1")}</p>
+              <p className="text-lg text-text leading-relaxed">{t("bio1")}</p>
               <p className="text-lg text-text leading-relaxed">{t("bio2")}</p>
               <p className="text-lg text-text leading-relaxed">{t("bio3")}</p>
             </div>
@@ -64,7 +64,7 @@ export default function AboutSection() {
             <div className="mt-8">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("cta")}
               </Link>

--- a/src/components/home/BenefitsSection.tsx
+++ b/src/components/home/BenefitsSection.tsx
@@ -31,7 +31,7 @@ export default function BenefitsSection() {
             <div className="mt-10">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-primary-dark text-text-inverse font-semibold px-8 py-4 rounded-full hover:bg-secondary hover:text-text-dark hover:shadow-glow transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-primary-dark text-text-inverse font-semibold px-8 py-4 rounded-full hover:bg-secondary hover:text-text-dark hover:shadow-glow transition-all duration-300"
               >
                 {t("cta")}
               </Link>
@@ -53,7 +53,7 @@ export default function BenefitsSection() {
                 className="flex items-start gap-5 p-6 rounded-2xl bg-background-alt border border-border shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 group"
               >
                 <div className="w-12 h-12 rounded-xl bg-secondary/10 flex items-center justify-center shrink-0 group-hover:bg-secondary group-hover:scale-110 transition-all duration-300">
-                  <CheckIcon className="w-6 h-6 text-secondary group-hover:text-text-dark transition-colors duration-300" />
+                  <CheckIcon className="w-6 h-6 text-primary group-hover:text-text-dark transition-colors duration-300" />
                 </div>
                 <p className="text-lg font-medium text-text-dark leading-relaxed pt-2">{text}</p>
               </motion.div>

--- a/src/components/home/DifferentiationSection.tsx
+++ b/src/components/home/DifferentiationSection.tsx
@@ -13,7 +13,7 @@ export default function DifferentiationSection() {
   const differentiators = [t("item1"), t("item2"), t("item3"), t("item4")];
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_50%,_rgba(245,158,11,0.05)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_50%,_rgba(185,216,235,0.05)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
@@ -40,7 +40,7 @@ export default function DifferentiationSection() {
                 className="flex items-center gap-4 p-5 rounded-xl bg-card border border-border hover:bg-card-hover hover:border-secondary/20 transition-all duration-300"
               >
                 <div className="w-8 h-8 rounded-full bg-secondary/15 flex items-center justify-center shrink-0">
-                  <CheckIcon className="w-4 h-4 text-secondary" />
+                  <CheckIcon className="w-4 h-4 text-primary" />
                 </div>
                 <p className="text-text-dark font-medium">{text}</p>
               </motion.div>

--- a/src/components/home/FinalCtaSection.tsx
+++ b/src/components/home/FinalCtaSection.tsx
@@ -9,7 +9,7 @@ export default function FinalCtaSection() {
   const t = useTranslations("FinalCtaSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,_rgba(245,158,11,0.08)_0%,_transparent_70%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,_rgba(185,216,235,0.08)_0%,_transparent_70%)]" />
 
       <div className="relative z-10 max-w-4xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32 text-center">
         <AnimatedSection>
@@ -20,7 +20,7 @@ export default function FinalCtaSection() {
           <div className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
             >
               {t("cta")}
             </Link>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -14,7 +14,7 @@ export default function HeroSection() {
   return (
     <section className="relative min-h-screen flex items-center overflow-hidden bg-background">
       {/* Background layers */}
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_80%_20%,_rgba(245,158,11,0.08)_0%,_transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_80%_20%,_rgba(185,216,235,0.08)_0%,_transparent_50%)]" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_20%_80%,_rgba(28,71,97,0.25)_0%,_transparent_60%)]" />
 
       {/* Subtle noise texture overlay */}
@@ -30,7 +30,7 @@ export default function HeroSection() {
       <div className="absolute top-0 right-[15%] w-px h-full bg-gradient-to-b from-transparent via-border to-transparent" />
       <div className="absolute top-0 right-[35%] w-px h-full bg-gradient-to-b from-transparent via-card to-transparent hidden lg:block" />
 
-      <div className="relative z-10 w-full max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-28 lg:py-0">
+      <div className="relative z-10 w-full max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-28 lg:pt-24 lg:pb-10">
         <div className="grid lg:grid-cols-12 gap-10 lg:gap-8 items-center min-h-[85vh]">
           {/* Text column */}
           <motion.div
@@ -50,7 +50,7 @@ export default function HeroSection() {
               {t("headingLine1")}
               <br />
               {t("headingBeforeHighlight")}
-              <span className="text-secondary relative">
+              <span className="text-primary relative">
                 {t("headingHighlight")}
                 <svg className="absolute -bottom-2 left-0 w-full" viewBox="0 0 200 12" fill="none">
                   <title>Underline decoration</title>
@@ -59,7 +59,7 @@ export default function HeroSection() {
                     stroke="currentColor"
                     strokeWidth="3"
                     strokeLinecap="round"
-                    className="text-secondary/60"
+                    className="text-primary/60"
                   />
                 </svg>
               </span>
@@ -76,15 +76,9 @@ export default function HeroSection() {
             <motion.div variants={fadeInUp} className="mt-10 flex flex-col sm:flex-row gap-4">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("ctaPrimary")}
-              </Link>
-              <Link
-                href="/servicios"
-                className="inline-flex items-center justify-center text-text-dark font-medium text-base px-8 py-4 rounded-full border border-border hover:bg-card-hover hover:border-secondary/30 transition-all duration-300"
-              >
-                {t("ctaSecondary")}
               </Link>
             </motion.div>
 
@@ -122,7 +116,7 @@ export default function HeroSection() {
               {/* Main image container with asymmetric frame */}
               <div className="relative aspect-[3/4] rounded-[2rem] overflow-hidden shadow-2xl shadow-black/40 border border-border">
                 <Image
-                  src="/wp/home-hero.webp"
+                  src="/profile/pere1-transparente.webp"
                   alt={t("heroImageAlt")}
                   fill
                   sizes="(max-width: 768px) 80vw, 480px"

--- a/src/components/home/PainPointsSection.tsx
+++ b/src/components/home/PainPointsSection.tsx
@@ -18,7 +18,7 @@ export default function PainPointsSection() {
   ];
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,_rgba(245,158,11,0.06)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <AnimatedSection className="max-w-2xl mb-16">
@@ -41,11 +41,8 @@ export default function PainPointsSection() {
               variants={scaleIn}
               className="group relative bg-card border border-border rounded-2xl p-7 lg:p-8 hover:bg-card-hover hover:border-secondary/30 hover:-translate-y-1 transition-all duration-500"
             >
-              <span className="text-secondary/40 text-5xl font-bold absolute top-6 right-6 select-none">
-                {item.num}
-              </span>
               <div className="w-10 h-10 rounded-full bg-secondary/10 flex items-center justify-center mb-5">
-                <span className="text-secondary font-bold text-sm">{item.num}</span>
+                <span className="text-primary font-bold text-sm">{item.num}</span>
               </div>
               <p className="text-text-dark text-lg leading-relaxed relative z-10">{item.text}</p>
             </motion.div>

--- a/src/components/home/ProcessSection.tsx
+++ b/src/components/home/ProcessSection.tsx
@@ -46,7 +46,7 @@ export default function ProcessSection() {
               >
                 <div className="flex flex-col lg:flex-row items-center lg:items-start gap-4">
                   <div className="relative">
-                    <div className="w-16 h-16 rounded-2xl bg-secondary/10 border border-secondary/20 flex items-center justify-center text-secondary font-bold text-xl z-10 relative">
+                    <div className="w-16 h-16 rounded-2xl bg-secondary/10 border border-secondary/20 flex items-center justify-center text-primary font-bold text-xl z-10 relative">
                       {item.step}
                     </div>
                     <div className="absolute inset-0 bg-secondary/20 rounded-2xl blur-lg" />

--- a/src/components/privacy/PrivacyContentSection.tsx
+++ b/src/components/privacy/PrivacyContentSection.tsx
@@ -14,7 +14,7 @@ interface PrivacyItemProps {
 function PrivacyItem({ icon, label }: PrivacyItemProps) {
   return (
     <div className="flex items-center gap-3 text-text-light text-sm">
-      <span className="text-secondary">{icon}</span>
+      <span className="text-primary">{icon}</span>
       <span>{label}</span>
     </div>
   );
@@ -161,7 +161,7 @@ export default function PrivacyContentSection() {
 
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_20%,_rgba(245,158,11,0.03)_0%,_transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_20%,_rgba(185,216,235,0.03)_0%,_transparent_50%)]" />
 
       <div className="relative z-10 max-w-4xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <motion.div

--- a/src/components/privacy/PrivacyHeroSection.tsx
+++ b/src/components/privacy/PrivacyHeroSection.tsx
@@ -10,7 +10,7 @@ export default function PrivacyHeroSection() {
   const t = useTranslations("PrivacyHeroSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(245,158,11,0.06)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
       <div className="absolute top-0 right-[25%] w-px h-full bg-gradient-to-b from-transparent via-white/5 to-transparent" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">

--- a/src/components/servicios/ServiciosCtaSection.tsx
+++ b/src/components/servicios/ServiciosCtaSection.tsx
@@ -9,7 +9,7 @@ export default function ServiciosCtaSection() {
   const t = useTranslations("ServiciosCtaSection");
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,_rgba(245,158,11,0.08)_0%,_transparent_70%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,_rgba(185,216,235,0.08)_0%,_transparent_70%)]" />
 
       <div className="relative z-10 max-w-4xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32 text-center">
         <AnimatedSection>
@@ -19,7 +19,7 @@ export default function ServiciosCtaSection() {
           <div className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
             >
               {t("cta")}
             </Link>

--- a/src/components/servicios/ServiciosHeroSection.tsx
+++ b/src/components/servicios/ServiciosHeroSection.tsx
@@ -11,7 +11,7 @@ export default function ServiciosHeroSection() {
   const t = useTranslations("ServiciosHeroSection");
   return (
     <section className="relative min-h-[70vh] flex items-center overflow-hidden bg-background">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_70%,_rgba(245,158,11,0.08)_0%,_transparent_50%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_70%,_rgba(185,216,235,0.08)_0%,_transparent_50%)]" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_70%_30%,_rgba(28,71,97,0.25)_0%,_transparent_60%)]" />
 
       <div className="absolute top-0 left-[25%] w-px h-full bg-gradient-to-b from-transparent via-white/5 to-transparent" />
@@ -44,7 +44,7 @@ export default function ServiciosHeroSection() {
           <motion.div variants={fadeInUp} className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
             >
               {t("cta")}
             </Link>

--- a/src/components/servicios/ServiciosNotThisSection.tsx
+++ b/src/components/servicios/ServiciosNotThisSection.tsx
@@ -65,7 +65,7 @@ export default function ServiciosNotThisSection() {
 
           <div>
             <AnimatedSection>
-              <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1] lg:mt-16">
+              <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1]">
                 {t("yesHeading")}
               </h2>
             </AnimatedSection>
@@ -87,7 +87,7 @@ export default function ServiciosNotThisSection() {
                     <svg
                       role="img"
                       aria-label="Checkmark"
-                      className="w-4 h-4 text-secondary"
+                      className="w-4 h-4 text-primary"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"

--- a/src/components/servicios/ServiciosPainSection.tsx
+++ b/src/components/servicios/ServiciosPainSection.tsx
@@ -18,7 +18,7 @@ export default function ServiciosPainSection() {
   ];
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_0%,_rgba(245,158,11,0.06)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_0%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <AnimatedSection className="max-w-2xl mb-16">
@@ -41,11 +41,8 @@ export default function ServiciosPainSection() {
               variants={scaleIn}
               className="group relative bg-card border border-border rounded-2xl p-7 lg:p-8 hover:bg-card-hover hover:border-secondary/30 hover:-translate-y-1 transition-all duration-500"
             >
-              <span className="text-secondary/40 text-5xl font-bold absolute top-6 right-6 select-none">
-                {item.num}
-              </span>
               <div className="w-10 h-10 rounded-full bg-secondary/10 flex items-center justify-center mb-5">
-                <span className="text-secondary font-bold text-sm">{item.num}</span>
+                <span className="text-primary font-bold text-sm">{item.num}</span>
               </div>
               <p className="text-text text-lg leading-relaxed relative z-10">{item.text}</p>
             </motion.div>

--- a/src/components/servicios/ServiciosProblemSection.tsx
+++ b/src/components/servicios/ServiciosProblemSection.tsx
@@ -12,7 +12,7 @@ export default function ServiciosProblemSection() {
   const items = [t("item1"), t("item2"), t("item3"), t("item4")];
   return (
     <section className="relative bg-background-alt overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(245,158,11,0.05)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(185,216,235,0.05)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
@@ -44,7 +44,7 @@ export default function ServiciosProblemSection() {
                 className="flex items-center gap-4 p-5 rounded-xl bg-card border border-border hover:bg-card-hover hover:border-secondary/20 transition-all duration-300"
               >
                 <div className="w-8 h-8 rounded-full bg-secondary/15 flex items-center justify-center shrink-0">
-                  <CheckIcon className="w-4 h-4 text-secondary" />
+                  <CheckIcon className="w-4 h-4 text-primary" />
                 </div>
                 <p className="text-text font-medium">{text}</p>
               </motion.div>

--- a/src/components/servicios/ServiciosSessionSection.tsx
+++ b/src/components/servicios/ServiciosSessionSection.tsx
@@ -41,7 +41,7 @@ export default function ServiciosSessionSection() {
               variants={fadeInUp}
               className="flex gap-5 p-6 rounded-2xl bg-card border border-border hover:border-secondary/20 transition-all duration-300"
             >
-              <div className="w-12 h-12 rounded-2xl bg-secondary/10 border border-secondary/20 flex items-center justify-center text-secondary font-bold text-lg shrink-0">
+              <div className="w-12 h-12 rounded-2xl bg-secondary/10 border border-secondary/20 flex items-center justify-center text-primary font-bold text-lg shrink-0">
                 {item.step}
               </div>
               <div>

--- a/src/components/servicios/ServiciosTakeawaysSection.tsx
+++ b/src/components/servicios/ServiciosTakeawaysSection.tsx
@@ -12,7 +12,7 @@ export default function ServiciosTakeawaysSection() {
   const takeaways = [t("item1"), t("item2"), t("item3"), t("item4")];
   return (
     <section className="relative bg-background overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(245,158,11,0.06)_0%,_transparent_60%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_30%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-start">
@@ -43,7 +43,7 @@ export default function ServiciosTakeawaysSection() {
                 className="flex items-center gap-4 p-5 rounded-xl bg-card border border-border hover:bg-card-hover hover:border-secondary/20 transition-all duration-300"
               >
                 <div className="w-8 h-8 rounded-full bg-secondary/15 flex items-center justify-center shrink-0">
-                  <CheckIcon className="w-4 h-4 text-secondary" />
+                  <CheckIcon className="w-4 h-4 text-primary" />
                 </div>
                 <p className="text-text font-medium">{text}</p>
               </motion.div>

--- a/src/components/servicios/ServiciosWorkSection.tsx
+++ b/src/components/servicios/ServiciosWorkSection.tsx
@@ -39,7 +39,7 @@ export default function ServiciosWorkSection() {
               variants={fadeInUp}
               className="p-8 rounded-2xl bg-background-alt border border-border shadow-sm hover:shadow-md hover:-translate-y-1 transition-all duration-300 group"
             >
-              <span className="text-secondary/30 text-4xl font-bold">{item.icon}</span>
+              <span className="text-primary/30 text-4xl font-bold">{item.icon}</span>
               <h3 className="text-xl font-bold text-text-dark mt-3">{item.title}</h3>
               <p className="text-text mt-2 leading-relaxed">{item.desc}</p>
             </motion.div>

--- a/src/messages/ca.json
+++ b/src/messages/ca.json
@@ -73,8 +73,8 @@
     "checkFreeSession": "Sessió inicial gratuïta",
     "checkPersonalized": "100% personalitzat",
     "checkOnline": "Online",
-    "statNumber": "+10",
-    "statLabel": "anys d'experiència",
+    "statNumber": "2018",
+    "statLabel": "Vaig començar",
     "badgeText": "Alt rendiment",
     "scrollIndicator": "Descobreix més",
     "heroImageAlt": "Pere Barceló - Psicòleg Esportiu"
@@ -82,11 +82,11 @@
   "PainPointsSection": {
     "sectionLabel": "Per a tu",
     "heading": "Això és per a tu si al competir...",
-    "point1": "01. Comences bé, però després d'un error t'enfonses",
-    "point2": "02. Apareixen dubtes que no tens entrenant",
-    "point3": "03. Et notes més tens i menys fluid",
-    "point4": "04. Penses massa en lloc de competir",
-    "point5": "05. Sents que podries rendir més, però alguna cosa falla",
+    "point1": "Comences bé, però després d'un error t'enfonses",
+    "point2": "Apareixen dubtes que no tens entrenant",
+    "point3": "Et notes més tens i menys fluid",
+    "point4": "Penses massa en lloc de competir",
+    "point5": "Sents que podries rendir més, però alguna cosa falla",
     "emphasis": "No és falta de nivell. És com gestiones el que passa al teu cap quan competeixes."
   },
   "BenefitsSection": {
@@ -178,7 +178,7 @@
   },
   "AboutWhySection": {
     "sectionLabel": "Motivació",
-    "heading": "Per què faig això",
+    "heading": "¿Per què faig això?",
     "paragraph1": "He vist a molts esportistes amb nivell quedar-se lluny del seu rendiment real.",
     "paragraph2": "No per falta d'entrenament. No per falta de talent.",
     "paragraph3": "Sinó per no saber gestionar el que passa al seu cap quan competeixen.",
@@ -187,7 +187,7 @@
   },
   "AboutExpectSection": {
     "sectionLabel": "Expectatives",
-    "heading": "Què pots esperar al treballar amb mi",
+    "heading": "¿Què pots esperar al treballar amb mi?",
     "item1": "No treballem sobre teoria, sinó sobre el que et passa competint",
     "item2": "Baixem a terra cada situació",
     "item3": "Surtos de cada sessió amb accions concretes",
@@ -218,12 +218,12 @@
   },
   "ServiciosPainSection": {
     "sectionLabel": "Per a tu",
-    "heading": "Et passa això quan competeixes?",
-    "point1": "01. Comences bé, però un error canvia el teu rendiment",
-    "point2": "02. Apareixen dubtes que no tens entrenant",
-    "point3": "03. Et tenses i perds fluïdesa",
-    "point4": "04. Penses massa en lloc de competir",
-    "point5": "05. La teva confiança depèn del resultat o del moment",
+    "heading": "¿Et passa això quan competeixes?",
+    "point1": "Comences bé, però un error canvia el teu rendiment",
+    "point2": "Apareixen dubtes que no tens entrenant",
+    "point3": "Et tenses i perds fluïdesa",
+    "point4": "Penses massa en lloc de competir",
+    "point5": "La teva confiança depèn del resultat o del moment",
     "emphasis": "No és falta de nivell. És gestió del rendiment sota pressió."
   },
   "ServiciosProblemSection": {
@@ -238,7 +238,7 @@
   },
   "ServiciosWorkSection": {
     "sectionLabel": "Contingut",
-    "heading": "Què treballarem",
+    "heading": "¿Què treballarem?",
     "subtitle": "Situacions reals de competició:",
     "topic1Title": "Després d'un error",
     "topic1Desc": "Com tallar la caiguda de rendiment i tornar al partit/competició",
@@ -251,7 +251,7 @@
   },
   "ServiciosTakeawaysSection": {
     "sectionLabel": "Resultats",
-    "heading": "Què t'emportaràs",
+    "heading": "¿Què t'emportaràs?",
     "subtitle": "No és teoria, és aplicació directa. Eines que pots usar des de la primera sessió.",
     "item1": "Què fer just després d'un error",
     "item2": "Com gestionar pensaments en competició",
@@ -260,7 +260,7 @@
   },
   "ServiciosSessionSection": {
     "sectionLabel": "Procés",
-    "heading": "Com és una sessió",
+    "heading": "¿Com és una sessió?",
     "subtitle": "A cada sessió treballem el teu cas real.",
     "step1Title": "1. Analitzem situacions concretes de competició",
     "step1Desc": "No parlem en general. Treballem el teu cas real.",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -73,8 +73,8 @@
     "checkFreeSession": "Sesión inicial gratuita",
     "checkPersonalized": "100% personalizado",
     "checkOnline": "Online",
-    "statNumber": "+10",
-    "statLabel": "años de experiencia",
+    "statNumber": "2018",
+    "statLabel": "Empecé en",
     "badgeText": "Alto rendimiento",
     "scrollIndicator": "Descubre más",
     "heroImageAlt": "Pere Barceló - Psicólogo Deportivo"
@@ -82,11 +82,11 @@
   "PainPointsSection": {
     "sectionLabel": "Para ti",
     "heading": "Esto es para ti si al competir...",
-    "point1": "01. Empiezas bien, pero tras un error te vienes abajo",
-    "point2": "02. Aparecen dudas que no tienes entrenando",
-    "point3": "03. Te notas más tenso y menos fluido",
-    "point4": "04. Piensas demasiado en lugar de competir",
-    "point5": "05. Sientes que podrías rendir más, pero algo falla",
+    "point1": "Empiezas bien, pero tras un error te vienes abajo",
+    "point2": "Aparecen dudas que no tienes entrenando",
+    "point3": "Te notas más tenso y menos fluido",
+    "point4": "Piensas demasiado en lugar de competir",
+    "point5": "Sientes que podrías rendir más, pero algo falla",
     "emphasis": "No es falta de nivel. Es cómo gestionas lo que pasa en tu cabeza cuando compites."
   },
   "BenefitsSection": {
@@ -178,7 +178,7 @@
   },
   "AboutWhySection": {
     "sectionLabel": "Motivación",
-    "heading": "Por qué hago esto",
+    "heading": "¿Por qué hago esto?",
     "paragraph1": "He visto a muchos deportistas con nivel quedarse lejos de su rendimiento real.",
     "paragraph2": "No por falta de entrenamiento. No por falta de talento.",
     "paragraph3": "Sino por no saber gestionar lo que pasa en su cabeza cuando compiten.",
@@ -187,7 +187,7 @@
   },
   "AboutExpectSection": {
     "sectionLabel": "Expectativas",
-    "heading": "Qué puedes esperar al trabajar conmigo",
+    "heading": "¿Qué puedes esperar al trabajar conmigo?",
     "item1": "No trabajamos sobre teoría, sino sobre lo que te pasa compitiendo",
     "item2": "Bajamos a tierra cada situación",
     "item3": "Sales de cada sesión con acciones concretas",
@@ -219,11 +219,11 @@
   "ServiciosPainSection": {
     "sectionLabel": "Para ti",
     "heading": "¿Te pasa esto cuando compites?",
-    "point1": "01. Empiezas bien, pero un error cambia tu rendimiento",
-    "point2": "02. Aparecen dudas que no tienes entrenando",
-    "point3": "03. Te tensas y pierdes fluidez",
-    "point4": "04. Piensas demasiado en vez de competir",
-    "point5": "05. Tu confianza depende del resultado o del momento",
+    "point1": "Empiezas bien, pero un error cambia tu rendimiento",
+    "point2": "Aparecen dudas que no tienes entrenando",
+    "point3": "Te tensas y pierdes fluidez",
+    "point4": "Piensas demasiado en vez de competir",
+    "point5": "Tu confianza depende del resultado o del momento",
     "emphasis": "No es falta de nivel. Es gestión del rendimiento bajo presión."
   },
   "ServiciosProblemSection": {
@@ -238,7 +238,7 @@
   },
   "ServiciosWorkSection": {
     "sectionLabel": "Contenido",
-    "heading": "Qué trabajaremos",
+    "heading": "¿Qué trabajaremos?",
     "subtitle": "Situaciones reales de competición:",
     "topic1Title": "Después de un error",
     "topic1Desc": "Cómo cortar la caída de rendimiento y volver al partido/competición",
@@ -251,7 +251,7 @@
   },
   "ServiciosTakeawaysSection": {
     "sectionLabel": "Resultados",
-    "heading": "Qué vas a llevar",
+    "heading": "¿Qué te vas a llevar?",
     "subtitle": "No es teoría, es aplicación directa. Herramientas que puedes usar desde la primera sesión.",
     "item1": "Qué hacer justo después de un error",
     "item2": "Cómo gestionar pensamientos en competición",
@@ -260,7 +260,7 @@
   },
   "ServiciosSessionSection": {
     "sectionLabel": "Proceso",
-    "heading": "Cómo es una sesión",
+    "heading": "¿Cómo es una sesión?",
     "subtitle": "En cada sesión trabajamos tu caso real.",
     "step1Title": "1. Analizamos situaciones concretas de competición",
     "step1Desc": "No hablamos en general. Trabajamos tu caso real.",

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,9 +1,4 @@
-import {
-  EnvelopeIcon,
-  InstagramIcon,
-  LinkedinIcon,
-  TwitterIcon,
-} from "@/components/composables/Icons";
+import { EnvelopeIcon, InstagramIcon, LinkedinIcon } from "@/components/composables/Icons";
 import {
   type Club,
   PhoneFormats,
@@ -49,12 +44,6 @@ export const socialMediaLinksFooter: SocialCardProps[] = [
     Icon: InstagramIcon,
     link: "https://www.instagram.com/perebarcelopsico/",
     username: "@perebarcelopsico",
-  },
-  {
-    name: "Twitter",
-    Icon: TwitterIcon,
-    link: "https://x.com/PBarceloPsico",
-    username: "@PBarceloPsico",
   },
   // Easy to add more social media here
 ];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -78,7 +78,7 @@ export default {
       boxShadow: {
         card: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
         "card-hover": "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
-        glow: "0 0 20px rgba(245, 158, 11, 0.3)",
+        glow: "0 0 20px rgba(185, 216, 235, 0.3)",
       },
       transitionTimingFunction: {
         smooth: "cubic-bezier(0.4, 0, 0.2, 1)",


### PR DESCRIPTION
## Cambios realizados según feedback del cliente

### Inicio
- Actualizada experiencia: de '+10 años' a '2018 / Empecí en'
- Eliminado botón 'Ver cómo trabajo' y centrado texto de botones
- Corregido solapamiento de foto con navbar en versión PC
- Eliminado número decorado duplicado en tarjetas de motivos
- Unificado formato de texto en 'Quién soy'

### Sobre mí
- Cambiadas fotos a imagen con fondo transparente
- Eliminada repetición de 'Sobre mí' en sección bio
- Añadidos signos de interrogación ¿? a títulos de sección
- Reemplazado fondo oscuro del tercer párrafo por negrita

### Servicios
- Añadidos ¿? a todos los títulos de sección pertinentes
- Eliminado número decorado duplicado en tarjetas
- Niveladas columnas en sección de diferencia

### General
- Actualizado esquema de colores: azul marino (#122f41) y azul cielo (#b9d8eb)
- Eliminado enlace 'Contacto' de navbar (redundante con CTA)
- Eliminado X/Twitter del footer
- Actualizados todos los degradados decorativos al nuevo azul cielo
- Corregido contraste de texto en fondos claros