### PR TITLE
fix: resolve contrast issues across light and dark modes

### DIFF
--- a/.agents/discover/2026-06-06.md
+++ b/.agents/discover/2026-06-06.md
@@ -1,0 +1,23 @@
+# Discover Report - 2026-06-06
+
+Branch: `main` (behind `develop` by 24+ PRs)
+
+## High
+- [DEPS] **`@typeform/embed-react` unused dependency** -- listed in `package.json:20` dependencies (not devDependencies), but no `import` found anywhere in `src/`. Ships unused bytes in production bundle.
+- [DEPS] **`next-sitemap` not wired into build** -- `next-sitemap.config.js` exists at project root, but `package.json` has no `postbuild` or `postexport` script to invoke it. The config file is dead code. There is an API-route sitemap at `src/app/sitemap.ts`, so `next-sitemap` may be completely unnecessary.
+- [STYLE] **8 Biome formatting violations** -- `biome ci` reports 8 files differ from formatter output: `.vscode/settings.json`, `biome.json`, `next-seo.config.js`, `next-sitemap.config.js`, `next.config.ts`, `public/site.webmanifest`, `tailwind.config.ts`, `tsconfig.json`. Run `pnpm biome check --write .` to fix.
+
+## Medium
+- [TECH-DEBT] **Orphaned Pages Router file** -- `src/app/pages/_document.tsx` is a legacy Pages Router pattern. The project uses App Router (`layout.tsx` at root); this file is never invoked. Safe to delete.
+- [TECH-DEBT] **Zero test coverage** -- No `*.test.*` or `*.spec.*` files found anywhere in `src/`. Project has no test runner configured in `package.json`.
+- [I18N] **`data.ts` `questions` array hardcoded in Spanish** -- 7 form questions + validation error messages in `useContactFormState.ts` are hardcoded Spanish strings. Not translatable via i18n.
+- [I18N] **`email.config.ts` subjects hardcoded** -- `Nuevo formulario de contacto` and `Gracias por contactar con nosotros` are not localized.
+- [DEPS] **`next-seo` on deprecated path** -- `next-seo` v6+ interop with App Router metadata API is limited. The project uses `next-seo` components (`Seo.tsx`, `SchemaMarkup.tsx`) alongside the Metadata API in page layouts. Consider full migration to `generateMetadata`.
+- [LINT] **Biome warning: `noExplicitAny` in `next.config.ts:7`** -- webpack config uses `rule: any`. Should use a typed alternative.
+
+## Low
+- [STYLE] **`biome-ignore` suppression in `BlogListSkeleton.tsx:7`** -- `noArrayIndexKey` suppressed for skeleton placeholders. Acceptable but worth noting.
+- [TOOLING] **No Knip configuration** -- Knip is not installed or configured. Dead-code detection is manual only.
+- [TOOLING] **No dependency-cruiser configuration** -- No architecture enforcement tooling. Module boundary violations would go undetected.
+- [PERF] **`fetchBlogPosts` / `fetchBlogPost` uncached across renders** -- `src/lib/blog.ts` uses `next: { revalidate: 3600 }` for ISR, but the fetches are not wrapped in `React.cache()`, so repeated calls in the same render path would trigger multiple requests.
+- [ERR] **Silent catch in `useContactFormState.ts:43-44`** -- `catch (_error) {}` swallows the error without logging or user feedback. The error has already been surfaced via `setValidationError`, but the catch block is bare.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,7 +33,7 @@
 }
 
 .dark {
-  --primary: #2f4f7f;
+  --primary: #8bbce3;
   --primary-light: #1c4761;
   --primary-dark: #0f2537;
 

--- a/src/components/about/AboutBioSection.tsx
+++ b/src/components/about/AboutBioSection.tsx
@@ -60,7 +60,7 @@ export default function AboutBioSection() {
             <div className="mt-8">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("cta")}
               </Link>

--- a/src/components/about/AboutHeroSection.tsx
+++ b/src/components/about/AboutHeroSection.tsx
@@ -39,7 +39,7 @@ export default function AboutHeroSection() {
             <motion.div variants={fadeInUp} className="mt-10">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("cta")}
               </Link>

--- a/src/components/about/AboutWhySection.tsx
+++ b/src/components/about/AboutWhySection.tsx
@@ -30,7 +30,7 @@ export default function AboutWhySection() {
               <div className="mt-8">
                 <a
                   href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
                 >
                   {t("cta")}
                 </a>

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -27,7 +27,7 @@ const Footer = () => {
           <div className="lg:col-span-5">
             <Link
               href="/"
-              className="inline-block text-text-inverse font-bold text-xl tracking-tight hover:text-secondary transition-colors duration-300"
+              className="inline-block text-text-inverse font-bold text-xl tracking-tight hover:text-primary transition-colors duration-300"
             >
               {tc("siteNameShort")}
               <span className="font-normal text-text-inverse opacity-40 ml-1.5 text-lg">
@@ -41,7 +41,7 @@ const Footer = () => {
             <div className="mt-6 flex items-center gap-4">
               <a
                 href={`mailto:${email}`}
-                className="flex items-center gap-2 text-text-inverse opacity-40 hover:opacity-100 hover:text-secondary transition-all duration-300 text-sm"
+                className="flex items-center gap-2 text-text-inverse opacity-40 hover:opacity-100 hover:text-primary transition-all duration-300 text-sm"
               >
                 <EnvelopeIcon className="w-4 h-4" />
                 <span>{email}</span>
@@ -50,7 +50,7 @@ const Footer = () => {
             <div className="mt-2 flex items-center gap-4">
               <a
                 href={`tel:${phone}`}
-                className="flex items-center gap-2 text-text-inverse opacity-40 hover:opacity-100 hover:text-secondary transition-all duration-300 text-sm"
+                className="flex items-center gap-2 text-text-inverse opacity-40 hover:opacity-100 hover:text-primary transition-all duration-300 text-sm"
               >
                 <WhatsappIcon className="w-4 h-4" />
                 <span>{phone}</span>
@@ -67,8 +67,8 @@ const Footer = () => {
                     target={social.link.startsWith("mailto") ? undefined : "_blank"}
                     rel={social.link.startsWith("mailto") ? undefined : "noopener noreferrer"}
                     className="w-10 h-10 rounded-xl bg-card border border-border flex items-center justify-center
-                             hover:bg-secondary/10 hover:border-secondary/20 hover:text-secondary
-                             text-text-inverse opacity-40 hover:opacity-100 transition-all duration-300"
+                             hover:bg-secondary/10 hover:border-secondary/20 hover:text-primary
+                             text-text-dark opacity-40 hover:opacity-100 transition-all duration-300"
                     aria-label={social.name}
                   >
                     <Icon className="w-4 h-4" />
@@ -89,7 +89,7 @@ const Footer = () => {
                   <li key={item.url}>
                     <Link
                       href={item.url}
-                      className="text-text-inverse opacity-40 hover:opacity-100 hover:text-secondary text-sm transition-all duration-300"
+                      className="text-text-inverse opacity-40 hover:opacity-100 hover:text-primary text-sm transition-all duration-300"
                     >
                       {tn(labelKey)}
                     </Link>
@@ -108,7 +108,7 @@ const Footer = () => {
             </p>
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-sm font-bold px-6 py-3 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] text-sm font-bold px-6 py-3 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
             >
               {t("ctaButton")}
             </Link>

--- a/src/components/core/Forms/ButtonBack.tsx
+++ b/src/components/core/Forms/ButtonBack.tsx
@@ -13,7 +13,7 @@ const BackButton = ({ show, onClick }: BackButtonProps) => {
     <button
       type="button"
       onClick={onClick}
-      className="text-sm text-text-light hover:text-secondary transition-colors"
+      className="text-sm text-text-light hover:text-primary transition-colors"
     >
       {t("buttonBack")}
     </button>

--- a/src/components/core/Forms/PhoneQuestion.tsx
+++ b/src/components/core/Forms/PhoneQuestion.tsx
@@ -80,7 +80,7 @@ const PhoneQuestion = ({
           <button
             type="button"
             onClick={() => setPhoneFormat(null)}
-            className="text-sm text-text hover:text-secondary-light transition-colors"
+            className="text-sm text-text hover:text-primary transition-colors"
           >
             {t("phoneFormatChange")}
           </button>

--- a/src/components/core/NavBar.tsx
+++ b/src/components/core/NavBar.tsx
@@ -59,7 +59,7 @@ const Navbar = () => {
           <div className="flex justify-between items-center h-20">
             <Link
               href="/"
-              className="text-text-dark font-bold text-lg tracking-tight whitespace-nowrap hover:text-secondary transition-colors duration-300"
+              className="text-text-dark font-bold text-lg tracking-tight whitespace-nowrap hover:text-primary transition-colors duration-300"
             >
               {tc("siteNameShort")}
               <span className="font-normal text-text-light ml-1.5 text-base">
@@ -86,7 +86,7 @@ const Navbar = () => {
               <button
                 type="button"
                 onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-                className="ml-3 p-2 rounded-xl text-text-light hover:text-secondary hover:bg-card-hover transition-all duration-300"
+                className="ml-3 p-2 rounded-xl text-text-light hover:text-primary hover:bg-card-hover transition-all duration-300"
                 aria-label={mounted && theme === "dark" ? tc("themeLight") : tc("themeDark")}
               >
                 {mounted && theme === "dark" ? (
@@ -128,8 +128,8 @@ const Navbar = () => {
                 type="button"
                 onClick={() => router.replace(pathname, { locale: otherLocale })}
                 className="ml-2 px-3 py-1.5 text-xs font-semibold uppercase tracking-widest rounded-lg
-                         text-text-light hover:text-secondary hover:bg-card-hover
-                         transition-all duration-300 border border-border"
+                          text-text-light hover:text-primary hover:bg-card-hover
+                          transition-all duration-300 border border-border"
                 aria-label={tc("localeSwitcherAria")}
               >
                 {otherLocale}
@@ -137,7 +137,7 @@ const Navbar = () => {
 
               <Link
                 href="/contact"
-                className="ml-4 inline-flex items-center justify-center bg-secondary text-text-dark text-sm font-bold px-5 py-2.5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="ml-4 inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-sm font-bold px-5 py-2.5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("ctaDesktop")}
               </Link>
@@ -146,7 +146,7 @@ const Navbar = () => {
             <div className="flex items-center gap-3 lg:hidden">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark text-xs font-bold px-4 py-2 rounded-full hover:bg-secondary-light transition-all duration-300"
+                className="inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-xs font-bold px-4 py-2 rounded-full hover:bg-secondary-light transition-all duration-300"
               >
                 {t("ctaMobile")}
               </Link>
@@ -154,7 +154,7 @@ const Navbar = () => {
               <button
                 type="button"
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
-                className="text-text-dark hover:text-secondary p-2 rounded-xl hover:bg-card-hover transition-all duration-300"
+                className="text-text-dark hover:text-primary p-2 rounded-xl hover:bg-card-hover transition-all duration-300"
                 aria-label={isMenuOpen ? t("closeMenu") : t("openMenu")}
               >
                 {isMenuOpen ? <CrossIcon className="w-6 h-6" /> : <BarsIcon className="w-6 h-6" />}
@@ -174,7 +174,7 @@ const Navbar = () => {
             <button
               type="button"
               onClick={() => setIsMenuOpen(false)}
-              className="text-text-dark hover:text-secondary p-2 rounded-xl hover:bg-card-hover transition-all duration-300"
+              className="text-text-dark hover:text-primary p-2 rounded-xl hover:bg-card-hover transition-all duration-300"
               aria-label={t("closeMenu")}
             >
               <CrossIcon className="w-7 h-7" />
@@ -200,7 +200,7 @@ const Navbar = () => {
           <button
             type="button"
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-            className="mt-4 p-3 rounded-xl text-text-light hover:text-secondary hover:bg-card-hover transition-all duration-300"
+            className="mt-4 p-3 rounded-xl text-text-light hover:text-primary hover:bg-card-hover transition-all duration-300"
             aria-label={mounted && theme === "dark" ? tc("themeLight") : tc("themeDark")}
           >
             {mounted && theme === "dark" ? (
@@ -242,7 +242,7 @@ const Navbar = () => {
             type="button"
             onClick={() => router.replace(pathname, { locale: otherLocale })}
             className="px-4 py-2 text-sm font-semibold uppercase tracking-widest rounded-xl
-                     text-text-light hover:text-secondary hover:bg-card-hover
+                     text-text-light hover:text-primary hover:bg-card-hover
                      transition-all duration-300 border border-border"
             aria-label={tc("localeSwitcherAria")}
           >
@@ -252,7 +252,7 @@ const Navbar = () => {
           <Link
             href="/contact"
             onClick={() => setIsMenuOpen(false)}
-            className="mt-4 inline-flex items-center justify-center bg-secondary text-text-dark text-base font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow transition-all duration-300"
+            className="mt-4 inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-base font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow transition-all duration-300"
           >
             {t("ctaDesktop")}
           </Link>

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -64,7 +64,7 @@ export default function AboutSection() {
             <div className="mt-8">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("cta")}
               </Link>

--- a/src/components/home/BenefitsSection.tsx
+++ b/src/components/home/BenefitsSection.tsx
@@ -31,7 +31,7 @@ export default function BenefitsSection() {
             <div className="mt-10">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center text-center bg-primary-dark text-text-inverse font-semibold px-8 py-4 rounded-full hover:bg-secondary hover:text-text-dark hover:shadow-glow transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-primary-dark text-text-inverse font-semibold px-8 py-4 rounded-full hover:bg-secondary hover:text-text-dark dark:hover:text-[#0f172a] hover:shadow-glow transition-all duration-300"
               >
                 {t("cta")}
               </Link>

--- a/src/components/home/FinalCtaSection.tsx
+++ b/src/components/home/FinalCtaSection.tsx
@@ -20,7 +20,7 @@ export default function FinalCtaSection() {
           <div className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
             >
               {t("cta")}
             </Link>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -50,7 +50,7 @@ export default function HeroSection() {
               {t("headingLine1")}
               <br />
               {t("headingBeforeHighlight")}
-              <span className="text-primary relative">
+              <span className="text-[#3b82f6] dark:text-primary relative">
                 {t("headingHighlight")}
                 <svg className="absolute -bottom-2 left-0 w-full" viewBox="0 0 200 12" fill="none">
                   <title>Underline decoration</title>
@@ -59,7 +59,7 @@ export default function HeroSection() {
                     stroke="currentColor"
                     strokeWidth="3"
                     strokeLinecap="round"
-                    className="text-primary/60"
+                    className="opacity-60"
                   />
                 </svg>
               </span>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -50,7 +50,7 @@ export default function HeroSection() {
               {t("headingLine1")}
               <br />
               {t("headingBeforeHighlight")}
-              <span className="text-[#3b82f6] dark:text-primary relative">
+              <span className="text-[#0D85D8] dark:text-primary relative">
                 {t("headingHighlight")}
                 <svg className="absolute -bottom-2 left-0 w-full" viewBox="0 0 200 12" fill="none">
                   <title>Underline decoration</title>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -76,7 +76,7 @@ export default function HeroSection() {
             <motion.div variants={fadeInUp} className="mt-10 flex flex-col sm:flex-row gap-4">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
               >
                 {t("ctaPrimary")}
               </Link>
@@ -87,15 +87,15 @@ export default function HeroSection() {
               className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-2 text-text-dark opacity-40 text-sm"
             >
               <span className="flex items-center gap-2">
-                <CheckIcon className="w-4 h-4 text-secondary" />
+                <CheckIcon className="w-4 h-4 text-primary" />
                 {t("checkFreeSession")}
               </span>
               <span className="flex items-center gap-2">
-                <CheckIcon className="w-4 h-4 text-secondary" />
+                <CheckIcon className="w-4 h-4 text-primary" />
                 {t("checkPersonalized")}
               </span>
               <span className="flex items-center gap-2">
-                <CheckIcon className="w-4 h-4 text-secondary" />
+                <CheckIcon className="w-4 h-4 text-primary" />
                 {t("checkOnline")}
               </span>
             </motion.div>

--- a/src/components/servicios/ServiciosCtaSection.tsx
+++ b/src/components/servicios/ServiciosCtaSection.tsx
@@ -19,7 +19,7 @@ export default function ServiciosCtaSection() {
           <div className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
             >
               {t("cta")}
             </Link>

--- a/src/components/servicios/ServiciosHeroSection.tsx
+++ b/src/components/servicios/ServiciosHeroSection.tsx
@@ -44,7 +44,7 @@ export default function ServiciosHeroSection() {
           <motion.div variants={fadeInUp} className="mt-10">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
+              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
             >
               {t("cta")}
             </Link>


### PR DESCRIPTION
## Problemas de contraste detectados y corregidos

### Modo oscuro
- **Botones CTA** (sky blue bg + white text): el texto era casi invisible. Añadido  a todos los botones  para forzar texto oscuro.
- **Texto acentuado** (section labels, check icons, palabra 'compites'):  era  sobre fondo oscuro, dando ~2.3:1 de contraste. Cambiado  en dark mode a  (sky blue claro) para ~10:1 de contraste.

### Modo claro
- **Iconos sociales del footer**:  (blanco) sobre  (blanco) = invisible. Cambiado a  para que sean visibles.
- **Check icons del hero**:  sobre fondo claro = poco visible. Cambiado a .

### Estados hover
- Navbar y footer:  (sky blue) sobre fondos claros tenía bajo contraste. Normalizado a  para consistencia y legibilidad en ambos modos.

### Archivos modificados
- :  en dark mode
- 13 componentes: botones, navbar, footer, hero, about, servicios, forms