### PR TITLE
[BUG] Fix #100: rename proxy.ts to middleware.ts to activate staging auth

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,7 +29,7 @@ function getUnauthorizedResponse(): NextResponse {
   });
 }
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
   const host = request.headers.get("host") || request.nextUrl.host;
   const url = request.nextUrl;
   const pathname = url.pathname;


### PR DESCRIPTION
## Description

Next.js **only** activates middleware from `middleware.ts`. The file was named `proxy.ts`, so staging auth protection, production redirects (www→non-www, HTTP→HTTPS), and intl routing were all silently skipped.

**Changes:**
- Rename `src/proxy.ts` → `src/middleware.ts`
- Rename exported function `proxy` → `middleware`
- The bare `catch {}` already has a clarifying comment — no functional change needed there

Closes #100

## Testing

- [x] Lints pass
- [x] Tests pass (5/5)
- [x] Type check passes