### PR TITLE
Polish homepage hero, unify section alignment, and improve visual consistency

### DIFF
--- a/src/components/about/AboutBioSection.tsx
+++ b/src/components/about/AboutBioSection.tsx
@@ -38,7 +38,7 @@ export default function AboutBioSection() {
           </motion.div>
 
           <motion.div
-            className="lg:col-span-7"
+            className="lg:col-span-7 text-center lg:text-left"
             initial={{ opacity: 0, x: 40 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
@@ -58,7 +58,7 @@ export default function AboutBioSection() {
               <p className="text-lg text-text leading-relaxed font-bold">{t("ctaText")}</p>
             </div>
 
-            <div className="mt-8">
+            <div className="mt-8 text-center">
               <Link
                 href="/contact"
                 className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"

--- a/src/components/about/AboutClubsSection.tsx
+++ b/src/components/about/AboutClubsSection.tsx
@@ -45,7 +45,7 @@ export default function AboutClubsSection() {
                   sizes="(max-width: 768px) 64px, 80px"
                 />
               </div>
-              <span className="text-xs sm:text-sm text-center font-medium text-text-light group-hover:text-text-dark transition-colors duration-300 line-clamp-2 leading-snug">
+              <span className="text-xs sm:text-sm text-center font-medium text-text-light group-hover:text-text-dark transition-colors duration-300 leading-snug">
                 {club.name}
               </span>
             </motion.div>

--- a/src/components/about/AboutHeroSection.tsx
+++ b/src/components/about/AboutHeroSection.tsx
@@ -36,7 +36,7 @@ export default function AboutHeroSection() {
               {t("heading")}
             </motion.h1>
 
-            <motion.div variants={fadeInUp} className="mt-10">
+            <motion.div variants={fadeInUp} className="mt-10 text-center">
               <Link
                 href="/contact"
                 className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"

--- a/src/components/about/AboutObjectiveSection.tsx
+++ b/src/components/about/AboutObjectiveSection.tsx
@@ -14,7 +14,7 @@ export default function AboutObjectiveSection() {
     <section className="relative bg-background overflow-hidden">
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
-          <AnimatedSection>
+          <AnimatedSection className="text-center lg:text-left">
             <SectionLabel text={t("sectionLabel")} />
             <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1]">
               {t("heading")}

--- a/src/components/about/AboutWhySection.tsx
+++ b/src/components/about/AboutWhySection.tsx
@@ -14,20 +14,20 @@ export default function AboutWhySection() {
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 lg:gap-24 items-center">
-          <AnimatedSection>
+          <AnimatedSection className="text-center lg:text-left">
             <SectionLabel text={t("sectionLabel")} />
             <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1]">
               {t("heading")}
             </h2>
           </AnimatedSection>
 
-          <AnimatedSection>
+          <AnimatedSection className="text-center lg:text-left">
             <div className="space-y-5">
               <p className="text-lg text-text leading-relaxed">{t("paragraph1")}</p>
               <p className="text-lg text-text leading-relaxed">{t("paragraph2")}</p>
               <p className="text-lg text-text leading-relaxed">{t("paragraph3")}</p>
               <p className="text-lg text-text-dark font-bold leading-relaxed">{t("highlight")}</p>
-              <div className="mt-8">
+              <div className="mt-8 text-center">
                 <a
                   href="/contact"
                   className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"

--- a/src/components/core/NavBar.tsx
+++ b/src/components/core/NavBar.tsx
@@ -145,7 +145,7 @@ const Navbar = () => {
             <div className="flex items-center gap-3 lg:hidden">
               <Link
                 href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-xs font-bold px-4 py-2 rounded-full hover:bg-secondary-light transition-all duration-300"
+                className="inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-xs font-bold px-3 py-2 rounded-full whitespace-nowrap hover:bg-secondary-light transition-all duration-300"
               >
                 {t("ctaMobile")}
               </Link>

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -21,7 +21,7 @@ export default function AboutSection() {
             viewport={{ once: true }}
             transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
           >
-            <div className="relative">
+            <div className="relative w-[280px] sm:w-[340px] lg:w-full mx-auto lg:mx-0">
               {/* Decorative offset frame */}
               <div className="absolute -bottom-4 -right-4 w-full h-full rounded-[2rem] border-2 border-secondary/30" />
               <div className="absolute -top-4 -left-4 w-24 h-24 border-l-2 border-t-2 border-secondary/20 rounded-tl-3xl" />
@@ -40,7 +40,7 @@ export default function AboutSection() {
 
           {/* Text */}
           <motion.div
-            className="lg:col-span-7"
+            className="lg:col-span-7 text-center lg:text-left"
             initial={{ opacity: 0, x: 40 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
@@ -61,7 +61,7 @@ export default function AboutSection() {
               <p className="text-lg font-bold">{t("highlight")}</p>
             </div>
 
-            <div className="mt-8">
+            <div className="mt-8 text-center">
               <Link
                 href="/contact"
                 className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"

--- a/src/components/home/BenefitsSection.tsx
+++ b/src/components/home/BenefitsSection.tsx
@@ -47,7 +47,7 @@ export default function BenefitsSection() {
               <motion.div
                 key={text}
                 variants={fadeInUp}
-                className="flex items-start gap-5 p-6 rounded-2xl bg-background-alt border border-border shadow-sm hover:shadow-md hover:-translate-y-1 transition-all duration-300 group"
+                className="flex flex-col items-center text-center sm:flex-row sm:items-start sm:text-left gap-5 p-6 rounded-2xl bg-background-alt border border-border shadow-sm hover:shadow-md hover:-translate-y-1 transition-all duration-300 group"
               >
                 <div className="w-12 h-12 rounded-xl bg-secondary/10 flex items-center justify-center shrink-0 group-hover:bg-secondary group-hover:scale-110 transition-all duration-300">
                   <CheckIcon className="w-6 h-6 text-primary group-hover:text-text-dark transition-colors duration-300" />

--- a/src/components/home/BenefitsSection.tsx
+++ b/src/components/home/BenefitsSection.tsx
@@ -17,13 +17,15 @@ export default function BenefitsSection() {
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 lg:gap-24 items-start">
           {/* Left: heading + CTA */}
-          <AnimatedSection className="lg:sticky lg:top-32">
+          <AnimatedSection className="lg:sticky lg:top-32 text-center">
             <SectionLabel text={t("sectionLabel")} />
             <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-text-dark tracking-tight leading-[1.1]">
               {t("heading")}
             </h2>
-            <p className="mt-6 text-lg text-text leading-relaxed max-w-md">{t("subtitle")}</p>
-            <div className="mt-10">
+            <p className="mt-6 text-lg text-text leading-relaxed max-w-md mx-auto">
+              {t("subtitle")}
+            </p>
+            <div className="mt-10 text-center">
               <Link
                 href="/contact"
                 className="inline-flex items-center justify-center text-center bg-primary-dark text-text-inverse font-semibold px-8 py-4 rounded-full hover:bg-secondary hover:text-text-dark dark:hover:text-[#0f172a] hover:shadow-glow transition-all duration-300"

--- a/src/components/home/DifferentiationSection.tsx
+++ b/src/components/home/DifferentiationSection.tsx
@@ -17,7 +17,7 @@ export default function DifferentiationSection() {
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
-          <AnimatedSection>
+          <AnimatedSection className="text-center lg:text-left">
             <SectionLabel text={t("sectionLabel")} />
             <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1]">
               {t("heading")}

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -8,9 +8,11 @@ import CheckIcon from "@/components/composables/CheckIcon";
 import SectionLabel from "@/components/composables/SectionLabel";
 import { fadeInUp, staggerContainer } from "@/components/home/animations";
 import { images } from "@/config/images";
+import { getYearsOfExperience } from "@/utils/experience";
 
 export default function HeroSection() {
   const t = useTranslations("HeroSection");
+  const years = getYearsOfExperience();
   return (
     <section className="relative min-h-screen flex items-center overflow-hidden bg-background">
       {/* Background layers */}
@@ -86,7 +88,10 @@ export default function HeroSection() {
               {t("subtitle")}
             </motion.p>
 
-            <motion.div variants={fadeInUp} className="mt-10 flex flex-col sm:flex-row gap-4">
+            <motion.div
+              variants={fadeInUp}
+              className="mt-10 flex flex-col sm:flex-row gap-4 items-center justify-center"
+            >
               <Link
                 href="/contact"
                 className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
@@ -97,7 +102,7 @@ export default function HeroSection() {
 
             <motion.div
               variants={fadeInUp}
-              className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-2 text-text-dark opacity-40 text-sm"
+              className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-text-dark opacity-40 text-sm"
             >
               <span className="flex items-center gap-2">
                 <CheckIcon className="w-4 h-4 text-primary" />
@@ -151,18 +156,23 @@ export default function HeroSection() {
 
               {/* Floating stat card */}
               <motion.div
-                className="absolute -left-6 sm:-left-10 bottom-12 bg-background-alt backdrop-blur-md border border-border rounded-2xl px-5 py-4 shadow-xl"
+                className="absolute -left-6 sm:-left-10 bottom-4 bg-background-alt backdrop-blur-md border border-border rounded-2xl px-5 py-4 shadow-xl"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.8, duration: 0.6 }}
               >
-                <p className="text-2xl font-bold text-text-dark">{t("statNumber")}</p>
-                <p className="text-xs text-text-light mt-0.5">{t("statLabel")}</p>
+                <p
+                  className="text-4xl font-bold text-text-dark text-center"
+                  suppressHydrationWarning
+                >
+                  {t("statNumber", { years })}
+                </p>
+                <p className="text-xs text-text-light mt-0.5 text-center">{t("statLabel")}</p>
               </motion.div>
 
               {/* Floating badge */}
               <motion.div
-                className="absolute -right-4 sm:-right-6 top-16 bg-secondary/90 backdrop-blur-sm rounded-full px-4 py-2 shadow-lg"
+                className="absolute -right-4 sm:-right-6 top-4 sm:top-6 bg-secondary/90 backdrop-blur-sm rounded-full px-4 py-2 shadow-lg"
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ delay: 1, duration: 0.6 }}

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -193,11 +193,11 @@ export default function HeroSection() {
         animate={{ opacity: 1 }}
         transition={{ delay: 1.4 }}
       >
-        <span className="text-text-dark opacity-30 text-xs uppercase tracking-widest">
+        <span className="text-text-light text-xs uppercase tracking-widest">
           {t("scrollIndicator")}
         </span>
         <motion.div
-          className="w-5 h-8 border-2 border-border rounded-full flex justify-center pt-1.5"
+          className="w-5 h-8 border-2 border-text-light/40 rounded-full flex justify-center pt-1.5"
           animate={{ y: [0, 6, 0] }}
           transition={{ repeat: Infinity, duration: 2, ease: "easeInOut" }}
         >

--- a/src/components/home/PainPointsSection.tsx
+++ b/src/components/home/PainPointsSection.tsx
@@ -21,7 +21,7 @@ export default function PainPointsSection() {
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,_rgba(185,216,235,0.06)_0%,_transparent_60%)]" />
 
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
-        <AnimatedSection className="max-w-2xl mb-16">
+        <AnimatedSection className="max-w-2xl mb-16 mx-auto text-center">
           <SectionLabel text={t("sectionLabel")} />
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-text-dark tracking-tight">
             {t("heading")}
@@ -49,7 +49,7 @@ export default function PainPointsSection() {
           ))}
         </motion.div>
 
-        <AnimatedSection className="mt-16 max-w-2xl">
+        <AnimatedSection className="mt-16 max-w-2xl mx-auto text-center">
           <p className="text-xl text-text-light leading-relaxed">{t("emphasis")}</p>
         </AnimatedSection>
       </div>

--- a/src/components/servicios/ServiciosHeroSection.tsx
+++ b/src/components/servicios/ServiciosHeroSection.tsx
@@ -18,7 +18,7 @@ export default function ServiciosHeroSection() {
 
       <div className="relative z-10 w-full max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-28 lg:py-0">
         <motion.div
-          className="max-w-3xl"
+          className="max-w-3xl mx-auto text-center"
           initial="hidden"
           animate="visible"
           variants={staggerContainer}
@@ -36,7 +36,7 @@ export default function ServiciosHeroSection() {
 
           <motion.p
             variants={fadeInUp}
-            className="mt-6 text-lg sm:text-xl text-text-light max-w-2xl leading-relaxed"
+            className="mt-6 text-lg sm:text-xl text-text-light max-w-2xl mx-auto leading-relaxed"
           >
             {t("subtitle")}
           </motion.p>

--- a/src/components/servicios/ServiciosHeroSection.tsx
+++ b/src/components/servicios/ServiciosHeroSection.tsx
@@ -41,7 +41,7 @@ export default function ServiciosHeroSection() {
             {t("subtitle")}
           </motion.p>
 
-          <motion.div variants={fadeInUp} className="mt-10">
+          <motion.div variants={fadeInUp} className="mt-10 text-center">
             <Link
               href="/contact"
               className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
@@ -49,7 +49,7 @@ export default function ServiciosHeroSection() {
               {t("cta")}
             </Link>
           </motion.div>
-          <motion.p variants={fadeInUp} className="mt-3 text-text-light text-sm">
+          <motion.p variants={fadeInUp} className="mt-3 text-text-light text-sm text-center">
             {t("finePrint")}
           </motion.p>
         </motion.div>

--- a/src/components/servicios/ServiciosNotThisSection.tsx
+++ b/src/components/servicios/ServiciosNotThisSection.tsx
@@ -22,7 +22,7 @@ export default function ServiciosNotThisSection() {
     <section className="relative bg-background overflow-hidden">
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16">
-          <div>
+          <div className="text-center lg:text-left">
             <AnimatedSection>
               <SectionLabel text={t("sectionLabel")} />
               <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1]">
@@ -63,7 +63,7 @@ export default function ServiciosNotThisSection() {
             </motion.div>
           </div>
 
-          <div>
+          <div className="text-center lg:text-left">
             <AnimatedSection>
               <h2 className="text-4xl sm:text-5xl font-bold text-text-dark tracking-tight leading-[1.1]">
                 {t("yesHeading")}

--- a/src/components/servicios/ServiciosProblemSection.tsx
+++ b/src/components/servicios/ServiciosProblemSection.tsx
@@ -17,6 +17,7 @@ export default function ServiciosProblemSection() {
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
           <motion.div
+            className="text-center lg:text-left"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}

--- a/src/components/servicios/ServiciosTakeawaysSection.tsx
+++ b/src/components/servicios/ServiciosTakeawaysSection.tsx
@@ -17,6 +17,7 @@ export default function ServiciosTakeawaysSection() {
       <div className="relative z-10 max-w-7xl mx-auto px-5 sm:px-8 lg:px-12 py-24 lg:py-32">
         <div className="grid lg:grid-cols-2 gap-16 items-start">
           <motion.div
+            className="text-center lg:text-left"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}

--- a/src/messages/ca.json
+++ b/src/messages/ca.json
@@ -20,7 +20,7 @@
     "servicios": "Serveis",
     "contact": "Contacte",
     "ctaDesktop": "Sessió gratuïta",
-    "ctaMobile": "Sessiógratis",
+    "ctaMobile": "Sessió gratis",
     "closeMenu": "Tancar menú",
     "openMenu": "Obrir menú"
   },
@@ -73,8 +73,8 @@
     "checkFreeSession": "Sessió inicial gratuïta",
     "checkPersonalized": "100% personalitzat",
     "checkOnline": "Online",
-    "statNumber": "2018",
-    "statLabel": "Vaig començar",
+    "statNumber": "+{years}",
+    "statLabel": "anys d'experiència",
     "badgeText": "Alt rendiment",
     "scrollIndicator": "Descobreix més",
     "heroImageAlt": "Pere Barceló - Psicòleg Esportiu"

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -20,7 +20,7 @@
     "servicios": "Servicios",
     "contact": "Contacto",
     "ctaDesktop": "Sesión gratuita",
-    "ctaMobile": "Sesióngratis",
+    "ctaMobile": "Sesión gratis",
     "closeMenu": "Cerrar menú",
     "openMenu": "Abrir menú"
   },
@@ -73,8 +73,8 @@
     "checkFreeSession": "Sesión inicial gratuita",
     "checkPersonalized": "100% personalizado",
     "checkOnline": "Online",
-    "statNumber": "2018",
-    "statLabel": "Empecé en",
+    "statNumber": "+{years}",
+    "statLabel": "años de experiencia",
     "badgeText": "Alto rendimiento",
     "scrollIndicator": "Descubre más",
     "heroImageAlt": "Pere Barceló - Psicólogo Deportivo"

--- a/src/utils/experience.ts
+++ b/src/utils/experience.ts
@@ -1,4 +1,4 @@
-export const EXPERIENCE_START_YEAR = 2018;
+const EXPERIENCE_START_YEAR = 2018;
 
 export function getYearsOfExperience(): number {
   return new Date().getFullYear() - EXPERIENCE_START_YEAR;

--- a/src/utils/experience.ts
+++ b/src/utils/experience.ts
@@ -1,0 +1,5 @@
+export const EXPERIENCE_START_YEAR = 2018;
+
+export function getYearsOfExperience(): number {
+  return new Date().getFullYear() - EXPERIENCE_START_YEAR;
+}


### PR DESCRIPTION
## Summary

Polish the homepage hero, unify section heading/CTA alignment across Home, About, and Servicios pages, and apply quick visual fixes found by design review.

## Changes

- **HeroSection**: Moved "Alto rendimiento" badge up, auto-calculated years-of-experience stat, centered CTA + checklist, increased scroll-indicator contrast
- **AboutSection**: Capped image size, aligned CTA
- **BenefitsSection**: Centered left column, centered cards on mobile
- **AboutClubsSection**: Removed club-name truncation
- **NavBar**: Mobile CTA stays on one line
- **ServiciosHeroSection**: Centered content (no supporting image)
- **Various sections**: Unified heading alignment (text-center lg:text-left) across Home, About, Servicios
- **New utility**: src/utils/experience.ts for years-of-experience calculation

## Commits

- 056df36 style(servicios): center hero section content
- 655765a style(home): center benefit cards on mobile
- f2b1732 style(about): show full club names instead of clamping
- ae92157 style(hero): improve scroll indicator contrast
- bdfb488 style(navbar): keep mobile cta on one line
- 5f4ac6d style(home): center section intros and compute experience years dynamically

## Checklist

- [x] pnpm type-check passes
- [x] pnpm lint passes
- [x] pnpm test passes