### PR TITLE
[BUG] fix(#100): rename proxy.ts to middleware.ts

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,7 +29,7 @@ function getUnauthorizedResponse(): NextResponse {
   });
 }
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
   const host = request.headers.get("host") || request.nextUrl.host;
   const url = request.nextUrl;
   const pathname = url.pathname;
@@ -60,7 +60,7 @@ export function proxy(request: NextRequest) {
         return response;
       }
     } catch {
-      // Malformed auth header
+      console.warn("[middleware] Malformed auth header from:", request.headers.get("host"));
     }
 
     return getUnauthorizedResponse();


### PR DESCRIPTION
## Description

Renames `src/proxy.ts` to `src/middleware.ts` so Next.js middleware is activated. Next.js only picks up middleware from `middleware.ts` by convention.

Also fixes the bare `catch {}` on line 62 to log a warning when a malformed auth header is received.

Closes #100

## Testing

- [x] Lints pass
- [x] Tests pass (5/5)
- [x] Type check passes