### PR TITLE
fix(csp): allow Vercel Live toolbar origins outside production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,69 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin();
 
+/**
+ * Build the Content-Security-Policy header.
+ *
+ * Vercel injects its Live Feedback toolbar (https://vercel.live/.../feedback.js
+ * plus a Pusher websocket and a few asset origins) on preview and development
+ * deployments only — never on production. Allow those origins outside
+ * production so the toolbar doesn't trip the CSP and pollute the console
+ * (which fails Lighthouse best-practices audits), while keeping the production
+ * policy locked down.
+ */
+function buildContentSecurityPolicy(): string {
+  const allowVercelLive = process.env.VERCEL_ENV !== "production";
+
+  const vercelLive = {
+    script: allowVercelLive ? ["https://vercel.live"] : [],
+    style: allowVercelLive ? ["https://vercel.live"] : [],
+    img: allowVercelLive ? ["https://vercel.live", "https://vercel.com"] : [],
+    font: allowVercelLive ? ["https://vercel.live", "https://assets.vercel.com"] : [],
+    connect: allowVercelLive
+      ? ["https://vercel.live", "wss://ws-us3.pusher.com", "https://*.pusher.com"]
+      : [],
+    frame: allowVercelLive ? ["https://vercel.live"] : [],
+  };
+
+  const directives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      "'unsafe-eval'",
+      "'unsafe-inline'",
+      "https://consent.cookiebot.com",
+      "https://www.googletagmanager.com",
+      "https://ssl.google-analytics.com",
+      ...vercelLive.script,
+    ],
+    "style-src": ["'self'", "'unsafe-inline'", ...vercelLive.style],
+    "img-src": ["'self'", "data:", "blob:", "https://*.calendly.com", ...vercelLive.img],
+    "font-src": ["'self'", ...vercelLive.font],
+    "connect-src": [
+      "'self'",
+      "https://*.resend.com",
+      "https://vitals.vercel-insights.com",
+      "https://consent.cookiebot.com",
+      "https://www.google-analytics.com",
+      ...vercelLive.connect,
+    ],
+    "frame-src": [
+      "'self'",
+      "https://calendly.com",
+      "https://consent.cookiebot.com",
+      ...vercelLive.frame,
+    ],
+    "frame-ancestors": ["'none'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'"],
+    "object-src": ["'none'"],
+  };
+
+  return Object.entries(directives)
+    .map(([directive, values]) => `${directive} ${values.join(" ")}`)
+    .join("; ");
+}
+
 const nextConfig: NextConfig = {
   /* config options here */
   webpack(config) {
@@ -85,7 +148,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Content-Security-Policy",
-            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://consent.cookiebot.com https://www.googletagmanager.com https://ssl.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.calendly.com; font-src 'self'; connect-src 'self' https://*.resend.com https://vitals.vercel-insights.com https://consent.cookiebot.com https://www.google-analytics.com; frame-src 'self' https://calendly.com https://consent.cookiebot.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'",
+            value: buildContentSecurityPolicy(),
           },
         ],
       },


### PR DESCRIPTION
## Problem

Lighthouse best-practices flagged two failing audits on preview deployments:
- **Browser errors were logged to the console**
- **Issues were logged in the Issues panel in Chrome DevTools**

Both came from a single CSP violation:

```
Loading the script 'https://vercel.live/_next-live/feedback/feedback.js'
violates the following Content Security Policy directive: "script-src ..."
```

Vercel injects its **Live Feedback toolbar** automatically on **preview and development deployments only** (never production). The static CSP in `next.config.ts` didn't include `vercel.live`, so the browser blocked it and polluted the console.

## Fix

Make the CSP **environment-aware**. `next.config.ts` now builds the policy via `buildContentSecurityPolicy()`, which adds the Vercel Live origins only when `VERCEL_ENV !== "production"`:

| Origin | Directive(s) | Purpose |
|---|---|---|
| `https://vercel.live` | script / style / img / font / connect / frame | the toolbar |
| `https://vercel.com` | img | toolbar assets |
| `https://assets.vercel.com` | font | toolbar fonts |
| `wss://ws-us3.pusher.com`, `https://*.pusher.com` | connect | live-presence websocket |

**Production CSP is unchanged** — no `vercel.live` is added there, so security and the production Lighthouse score are unaffected.

## Verification
- `tsc --noEmit` → no errors
- Confirmed: `production` → no `vercel.live`; `preview` / local → allowed
- Biome clean on the changed code

## Note
The CSP is an edge header, so the **preview must be redeployed** before re-running Lighthouse — the old preview still serves the old header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)