### PR TITLE
feat: canonical URLs for Vercel preview environments

### DIFF
--- a/src/app/__tests__/metadata.test.ts
+++ b/src/app/__tests__/metadata.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/config/server-env.config", () => ({
 
 vi.mock("@/lib/site", () => ({
   getSiteUrl: vi.fn().mockReturnValue("https://perebarcelopsicologo.com"),
+  getCanonicalUrl: vi.fn().mockReturnValue("https://perebarcelopsicologo.com"),
   getRobotsMetadata: vi.fn().mockReturnValue({
     index: true,
     follow: true,
@@ -49,7 +50,7 @@ describe("defaultMetadata", () => {
   });
 
   it("has alternates with canonical and hreflang", () => {
-    expect(defaultMetadata.alternates?.canonical).toBe("/");
+    expect(defaultMetadata.alternates?.canonical).toBe("https://perebarcelopsicologo.com");
     expect(defaultMetadata.alternates?.languages?.["x-default"]).toBe(
       "https://perebarcelopsicologo.com/",
     );

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { images } from "@/config/images";
 import { serverEnv } from "@/config/server-env.config";
-import { getRobotsMetadata, getSiteUrl } from "@/lib/site";
+import { getCanonicalUrl, getRobotsMetadata, getSiteUrl } from "@/lib/site";
 
 export const siteName = "Pere Barceló - Psicólogo Deportivo";
 const description =
@@ -11,6 +11,7 @@ const keywords =
 const googleVerification = serverEnv.GOOGLE_SITE_VERIFICATION;
 
 const siteUrl = getSiteUrl();
+const canonicalUrl = getCanonicalUrl();
 
 const defaultOgImage = {
   url: `${siteUrl}${images.ogDefault}`,
@@ -46,11 +47,11 @@ export const defaultMetadata: Metadata = {
   robots: getRobotsMetadata(),
   ...(googleVerification ? { verification: { google: googleVerification } } : {}),
   alternates: {
-    canonical: "/",
+    canonical: canonicalUrl,
     languages: {
-      "x-default": `${siteUrl}/`,
-      es: `${siteUrl}/`,
-      ca: `${siteUrl}/ca/`,
+      "x-default": `${canonicalUrl}/`,
+      es: `${canonicalUrl}/`,
+      ca: `${canonicalUrl}/ca/`,
     },
   },
   icons: {
@@ -83,7 +84,7 @@ export function createPageMetadata({
   imageUrl,
   keywords,
 }: PageMetadataOptions): Metadata {
-  const canonical = path === "/" ? siteUrl : `${siteUrl}${path}`;
+  const canonical = path === "/" ? canonicalUrl : `${canonicalUrl}${path}`;
   const resolvedImageUrl = imageUrl || (imagePath ? `${siteUrl}${imagePath}` : defaultOgImage.url);
   const images = [
     {
@@ -105,7 +106,7 @@ export function createPageMetadata({
       languages: {
         "x-default": canonical,
         es: canonical,
-        ca: `${siteUrl}/ca${path}`,
+        ca: `${canonicalUrl}/ca${path}`,
       },
     },
     openGraph: {

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -10,7 +10,9 @@ const Env = {
 type Environment = (typeof Env)[keyof typeof Env];
 
 const PRODUCTION_HOST = "perebarcelopsicologo.com";
+const STAGING_HOST = "app.perebarcelopsicologo.com";
 const STAGING_URL_PREFIX = "app.";
+const DEVELOP_BRANCH = "develop";
 
 export function getEnvironment(): Environment {
   if (process.env.VERCEL_ENV) {
@@ -21,7 +23,14 @@ export function getEnvironment(): Environment {
       }
       return Env.Production;
     }
-    if (process.env.VERCEL_ENV === Env.Preview) return Env.Preview;
+    if (process.env.VERCEL_ENV === Env.Preview) {
+      // Detect staging by branch name on Vercel preview deployments
+      const branch = process.env.VERCEL_GIT_COMMIT_REF || "";
+      if (branch === DEVELOP_BRANCH) {
+        return Env.Staging;
+      }
+      return Env.Preview;
+    }
     return Env.Development;
   }
 
@@ -37,16 +46,40 @@ export function isProduction(): boolean {
   return getEnvironment() === Env.Production;
 }
 
+export function isStaging(): boolean {
+  return getEnvironment() === Env.Staging;
+}
+
+export function isIndexable(): boolean {
+  return isProduction();
+}
+
 export function getSiteUrl(): string {
   return process.env.SITE_URL || `https://${PRODUCTION_HOST}`;
 }
 
+/**
+ * Returns the canonical URL for the current environment.
+ *
+ * Strategy:
+ * - Production: canonical = production domain
+ * - Staging (develop branch): canonical = staging domain
+ * - Other preview branches: canonical = production domain (prevents
+ *   duplicate content from random Vercel preview URLs)
+ */
+export function getCanonicalUrl(): string {
+  if (isStaging()) {
+    return `https://${STAGING_HOST}`;
+  }
+  return getSiteUrl();
+}
+
 export function getRobotsMetadata(): Metadata["robots"] {
-  const production = isProduction();
+  const indexable = isIndexable();
   return {
-    index: production,
-    follow: production,
-    ...(production && {
+    index: indexable,
+    follow: indexable,
+    ...(indexable && {
       googleBot: {
         index: true,
         follow: true,


### PR DESCRIPTION
## Changes

### Canonical URLs for Vercel Preview Environments

**Problem:** Vercel preview deployments get random URLs (`perebarcelopsicologo-abc123.vercel.app`) that should never be indexed. The `develop` branch needs a fixed staging domain (`app.perebarcelopsicologo.com`) as its canonical URL.

**Solution:** Smart canonical URL detection based on Vercel environment variables.

### Implementation

1. **`src/lib/site.ts`** - New helpers:
   - `getCanonicalUrl()` - Returns the right canonical URL per environment:
     - Production (`main`): `https://perebarcelopsicologo.com`
     - Staging (`develop`): `https://app.perebarcelopsicologo.com`
     - Other branches: `https://perebarcelopsicologo.com` (prevents duplicate content from random preview URLs)
   - `isStaging()` - Detects staging via `VERCEL_GIT_COMMIT_REF === "develop"`
   - `isIndexable()` - Only production is indexable

2. **`src/app/metadata.ts`** - Uses `getCanonicalUrl()` for:
   - `alternates.canonical`
   - `alternates.languages` (hreflang)

3. **`src/app/__tests__/metadata.test.ts`** - Updated mocks and expectations

### Environment Strategy

| Branch | Vercel Env | Canonical | robots | sitemap |
|--------|-----------|-----------|--------|---------|
| `main` | production | `perebarcelopsicologo.com` | index | yes |
| `develop` | preview | `app.perebarcelopsicologo.com` | noindex | no |
| feature/PR | preview | `perebarcelopsicologo.com` | noindex | no |

### Why this approach?
- **Develop branch**: Gets a fixed canonical so SEO tools can validate staging without random URLs changing on every deploy
- **Other branches**: Canonical points to production to prevent Google from indexing random preview URLs as duplicate content
- **All previews**: `noindex` via robots metadata prevents indexing regardless

### Vercel Configuration Required
None - `VERCEL_GIT_COMMIT_REF` and `VERCEL_ENV` are automatically available on Vercel deployments.

### Verification
- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm test` (44 tests) ✅
- `npx react-doctor` (100/100) ✅

---

Target: develop
