### PR TITLE
fix(calendly+csp): SSR-safe Calendly embed, per-request CSP nonces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   lint-and-test:
-    name: Lint, Type Check & Build
+    name: Lint, Type Check & Test
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   lint-and-test:
-    name: Lint, Type Check & Test
+    name: Lint, Type Check & Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -4,13 +4,36 @@
  * Origins are grouped by service so you can see at a glance which URLs
  * each third party needs. Scroll to `services` below.
  *
- * Vercel injects its Live Feedback toolbar (https://vercel.live/.../feedback.js
- * plus a Pusher websocket and a few asset origins) on preview and development
- * deployments only — never on production. Allow those origins outside
- * production so the toolbar doesn't trip the CSP and pollute the console
- * (which fails Lighthouse best-practices audits), while keeping the production
- * policy locked down.
+ * ## Nonce mode (production)
+ * A per-request nonce is injected via middleware. Next.js reads the nonce
+ * from the CSP response header and auto-applies it to every inline script
+ * it injects (hydration, flight data) and to all `next/script` components
+ * (GTM, Cookiebot). `'strict-dynamic'` lets nonce'd scripts load their own
+ * scripts transitively, so GTM can bootstrap without listing every child
+ * script origin.
+ *
+ * ## Dev mode
+ * Next.js dev server needs `'unsafe-eval'` (HMR/source maps) and
+ * `'unsafe-inline'` (quick eval). The nonce is skipped — dev is permissive.
+ *
+ * Vercel injects its Live Feedback toolbar on preview/dev deployments only.
+ * We allow those origins outside production so the toolbar doesn't trip the
+ * CSP and pollute the console (which fails Lighthouse best-practices).
  */
+
+export type CspOptions = {
+  /** Per-request nonce (base64). Required for production; skipped when isDev. */
+  nonce?: string;
+  /** True in local development (NODE_ENV=development). */
+  isDev?: boolean;
+};
+
+// CSP token constants — typo-proof.
+const SELF = "'self'" as const;
+const NONE = "'none'" as const;
+const UNSAFE_INLINE = "'unsafe-inline'" as const;
+const UNSAFE_EVAL = "'unsafe-eval'" as const;
+const STRICT_DYNAMIC = "'strict-dynamic'" as const;
 
 type DirectiveKey = "script" | "style" | "img" | "font" | "connect" | "frame";
 
@@ -67,7 +90,7 @@ function collect(directive: DirectiveKey): string[] {
   return Object.values(services).flatMap((s) => s[directive] ?? []);
 }
 
-export function buildContentSecurityPolicy(): string {
+export function buildContentSecurityPolicy({ nonce, isDev = false }: CspOptions = {}): string {
   const allowVercelLive = process.env.VERCEL_ENV !== "production";
 
   const vercelLive: ServiceOrigins = {
@@ -81,24 +104,34 @@ export function buildContentSecurityPolicy(): string {
     frame: allowVercelLive ? ["https://vercel.live"] : [],
   };
 
+  // script-src: strict with nonce in prod, permissive in dev.
+  const scriptSrc = isDev
+    ? [SELF, UNSAFE_INLINE, UNSAFE_EVAL, ...collect("script"), ...(vercelLive.script ?? [])]
+    : [
+        SELF,
+        `'nonce-${nonce}'`,
+        STRICT_DYNAMIC,
+        ...collect("script"),
+        ...(vercelLive.script ?? []),
+      ];
+
+  // style-src: always 'unsafe-inline' — Next.js injects inline styles
+  // (next/font, styled-jsx, Tailwind utilities). Noncing styles is fragile
+  // and the XSS risk of inline CSS is far lower than inline JS.
+  const styleSrc = [SELF, UNSAFE_INLINE, ...collect("style"), ...(vercelLive.style ?? [])];
+
   const directives: Record<string, string[]> = {
-    "default-src": ["'self'"],
-    "script-src": [
-      "'self'",
-      "'unsafe-eval'",
-      "'unsafe-inline'",
-      ...collect("script"),
-      ...(vercelLive.script ?? []),
-    ],
-    "style-src": ["'self'", "'unsafe-inline'", ...collect("style"), ...(vercelLive.style ?? [])],
-    "img-src": ["'self'", "data:", "blob:", ...collect("img"), ...(vercelLive.img ?? [])],
-    "font-src": ["'self'", ...(vercelLive.font ?? [])],
-    "connect-src": ["'self'", ...collect("connect"), ...(vercelLive.connect ?? [])],
-    "frame-src": ["'self'", ...collect("frame"), ...(vercelLive.frame ?? [])],
-    "frame-ancestors": ["'none'"],
-    "base-uri": ["'self'"],
-    "form-action": ["'self'"],
-    "object-src": ["'none'"],
+    "default-src": [SELF],
+    "script-src": scriptSrc,
+    "style-src": styleSrc,
+    "img-src": [SELF, "data:", "blob:", ...collect("img"), ...(vercelLive.img ?? [])],
+    "font-src": [SELF, ...(vercelLive.font ?? [])],
+    "connect-src": [SELF, ...collect("connect"), ...(vercelLive.connect ?? [])],
+    "frame-src": [SELF, ...collect("frame"), ...(vercelLive.frame ?? [])],
+    "frame-ancestors": [NONE],
+    "base-uri": [SELF],
+    "form-action": [SELF],
+    "object-src": [NONE],
   };
 
   return Object.entries(directives)

--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -1,6 +1,9 @@
 /**
  * Build the Content-Security-Policy header.
  *
+ * Origins are grouped by service so you can see at a glance which URLs
+ * each third party needs. Scroll to `services` below.
+ *
  * Vercel injects its Live Feedback toolbar (https://vercel.live/.../feedback.js
  * plus a Pusher websocket and a few asset origins) on preview and development
  * deployments only — never on production. Allow those origins outside
@@ -8,10 +11,66 @@
  * (which fails Lighthouse best-practices audits), while keeping the production
  * policy locked down.
  */
+
+type DirectiveKey = "script" | "style" | "img" | "font" | "connect" | "frame";
+
+type ServiceOrigins = Partial<Record<DirectiveKey, string[]>>;
+
+const services: Record<string, ServiceOrigins> = {
+  cookiebot: {
+    script: ["https://consent.cookiebot.com"],
+    style: ["https://consent.cookiebot.com"],
+    img: ["https://*.cookiebot.com"],
+    connect: ["https://consent.cookiebot.com"],
+    frame: ["https://consent.cookiebot.com"],
+  },
+  gtm: {
+    script: ["https://www.googletagmanager.com"],
+    img: ["https://www.googletagmanager.com"],
+    connect: ["https://www.googletagmanager.com"],
+    frame: ["https://www.googletagmanager.com"],
+  },
+  ga4: {
+    script: ["https://www.google-analytics.com", "https://ssl.google-analytics.com"],
+    img: ["https://www.google-analytics.com", "https://ssl.google-analytics.com"],
+    connect: ["https://*.google-analytics.com"],
+    frame: ["https://www.google-analytics.com"],
+  },
+  googleAds: {
+    script: ["https://www.googleadservices.com", "https://googleads.g.doubleclick.net"],
+    img: [
+      "https://www.googleadservices.com",
+      "https://googleads.g.doubleclick.net",
+      "https://www.google.com",
+    ],
+    connect: ["https://googleads.g.doubleclick.net"],
+    frame: [
+      "https://www.googleadservices.com",
+      "https://googleads.g.doubleclick.net",
+      "https://www.google.com",
+    ],
+  },
+  calendly: {
+    img: ["https://*.calendly.com"],
+    connect: ["https://*.calendly.com"],
+    frame: ["https://calendly.com", "https://*.calendly.com"],
+  },
+  resend: {
+    connect: ["https://*.resend.com"],
+  },
+  vercelInsights: {
+    connect: ["https://vitals.vercel-insights.com"],
+  },
+};
+
+function collect(directive: DirectiveKey): string[] {
+  return Object.values(services).flatMap((s) => s[directive] ?? []);
+}
+
 export function buildContentSecurityPolicy(): string {
   const allowVercelLive = process.env.VERCEL_ENV !== "production";
 
-  const vercelLive = {
+  const vercelLive: ServiceOrigins = {
     script: allowVercelLive ? ["https://vercel.live"] : [],
     style: allowVercelLive ? ["https://vercel.live"] : [],
     img: allowVercelLive ? ["https://vercel.live", "https://vercel.com"] : [],
@@ -28,28 +87,14 @@ export function buildContentSecurityPolicy(): string {
       "'self'",
       "'unsafe-eval'",
       "'unsafe-inline'",
-      "https://consent.cookiebot.com",
-      "https://www.googletagmanager.com",
-      "https://ssl.google-analytics.com",
-      ...vercelLive.script,
+      ...collect("script"),
+      ...(vercelLive.script ?? []),
     ],
-    "style-src": ["'self'", "'unsafe-inline'", ...vercelLive.style],
-    "img-src": ["'self'", "data:", "blob:", "https://*.calendly.com", ...vercelLive.img],
-    "font-src": ["'self'", ...vercelLive.font],
-    "connect-src": [
-      "'self'",
-      "https://*.resend.com",
-      "https://vitals.vercel-insights.com",
-      "https://consent.cookiebot.com",
-      "https://www.google-analytics.com",
-      ...vercelLive.connect,
-    ],
-    "frame-src": [
-      "'self'",
-      "https://calendly.com",
-      "https://consent.cookiebot.com",
-      ...vercelLive.frame,
-    ],
+    "style-src": ["'self'", "'unsafe-inline'", ...collect("style"), ...(vercelLive.style ?? [])],
+    "img-src": ["'self'", "data:", "blob:", ...collect("img"), ...(vercelLive.img ?? [])],
+    "font-src": ["'self'", ...(vercelLive.font ?? [])],
+    "connect-src": ["'self'", ...collect("connect"), ...(vercelLive.connect ?? [])],
+    "frame-src": ["'self'", ...collect("frame"), ...(vercelLive.frame ?? [])],
     "frame-ancestors": ["'none'"],
     "base-uri": ["'self'"],
     "form-action": ["'self'"],

--- a/config/headers.ts
+++ b/config/headers.ts
@@ -1,5 +1,8 @@
 import type { Header } from "next/dist/lib/load-custom-routes";
-import { buildContentSecurityPolicy } from "./content-security-policy";
+
+// Content-Security-Policy is set per-request by middleware (proxy.ts) with a
+// nonce — it cannot be a static header because the nonce must be unique
+// per request. All other security headers live here.
 
 export function buildHeaders(): Header[] {
   return [
@@ -29,10 +32,6 @@ export function buildHeaders(): Header[] {
         {
           key: "Strict-Transport-Security",
           value: "max-age=31536000; includeSubDomains; preload",
-        },
-        {
-          key: "Content-Security-Policy",
-          value: buildContentSecurityPolicy(),
         },
       ],
     },

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -16,6 +16,10 @@
       {
         "files": [".github/workflows/ci.yml"],
         "rules": ["react-doctor/build-pipeline-secret-boundary"]
+      },
+      {
+        "files": ["src/components/core/CalendlyBookingCard.tsx"],
+        "rules": ["react-doctor/iframe-missing-sandbox"]
       }
     ]
   }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -97,6 +97,10 @@ export default async function LocaleLayout({ children, params }: Props) {
             <link rel="dns-prefetch" href="https://consent.cookiebot.com" />
           </>
         )}
+        <link rel="preconnect" href="https://calendly.com" />
+        <link rel="dns-prefetch" href="https://calendly.com" />
+        <link rel="preconnect" href="https://assets.calendly.com" />
+        <link rel="dns-prefetch" href="https://assets.calendly.com" />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased`}

--- a/src/components/core/CalendlyBookingCard.tsx
+++ b/src/components/core/CalendlyBookingCard.tsx
@@ -1,16 +1,97 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { clientEnv } from "@/config/client-env.config";
 
-const calendlyUrl = clientEnv.NEXT_PUBLIC_CALENDLY_URL;
+const calendlyBaseUrl = clientEnv.NEXT_PUBLIC_CALENDLY_URL;
+
+const LOAD_TIMEOUT_MS = 8_000;
+
+// Known Calendly vendor warning (harmless):
+// "Cannot render a sync or defer <script> outside the main document..."
+// This is emitted by Calendly's own Next.js scripts inside the iframe.
+// It is cross-origin, so we cannot intercept it. Calendly works fine.
+// See: https://nextjs.org/docs/messages/next-script-legacy-behavior
+
+function estimateFrameHeight(containerWidth: number): number {
+  if (containerWidth < 640) return 1080;
+  if (containerWidth < 1024) return 920;
+  return 800;
+}
+
+function buildEmbedUrl(base: string): string {
+  const url = new URL(base);
+  url.searchParams.set("embed_domain", window.location.hostname);
+  url.searchParams.set("embed_type", "Inline");
+  return url.toString();
+}
+
+let cachedBaseUrl = "";
+let cachedEmbedUrl = "";
+
+function getEmbedUrl(baseUrl: string): string {
+  if (cachedBaseUrl !== baseUrl) {
+    cachedBaseUrl = baseUrl;
+    cachedEmbedUrl = buildEmbedUrl(baseUrl);
+  }
+  return cachedEmbedUrl;
+}
+
+function useEmbedUrl(baseUrl: string | undefined): string {
+  return useSyncExternalStore(
+    () => () => {},
+    () => {
+      if (typeof window !== "undefined" && baseUrl) {
+        return getEmbedUrl(baseUrl);
+      }
+      return "";
+    },
+    () => "",
+  );
+}
+
+function CalendlySkeleton() {
+  return (
+    <div className="flex flex-col gap-6 animate-pulse" aria-hidden>
+      <div className="flex gap-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex-1">
+            <div className="h-3 w-16 mx-auto rounded-full bg-text-light/10 mb-3" />
+            <div className="h-10 rounded-xl bg-text-light/10" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex gap-3">
+            <div className="h-3 w-20 rounded-full bg-text-light/10" />
+            <div className="flex-1 h-10 rounded-xl bg-text-light/10" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 const CalendlyBookingCard = () => {
   const t = useTranslations("CalendlyBookingCard");
-  const [iframeHeight, setIframeHeight] = useState(700);
-  const hasCalendly = Boolean(calendlyUrl);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState(920);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [timedOut, setTimedOut] = useState(false);
+  const embedUrl = useEmbedUrl(calendlyBaseUrl);
+  const hasCalendly = Boolean(calendlyBaseUrl);
+
+  const containerCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const ro = new ResizeObserver((entries) => {
+      const { width } = entries[0].contentRect;
+      setIframeHeight(estimateFrameHeight(width));
+    });
+    ro.observe(node);
+    return () => ro.disconnect();
+  }, []);
 
   useEffect(() => {
     const handleMessage = (e: MessageEvent) => {
@@ -31,30 +112,60 @@ const CalendlyBookingCard = () => {
     return () => window.removeEventListener("message", handleMessage);
   }, []);
 
-  return (
-    <div className="bg-background rounded-3xl shadow-card p-8 sm:p-10 h-full flex flex-col">
-      <span className="text-primary text-sm font-semibold uppercase tracking-widest">
-        {t("label")}
-      </span>
-      <h2 className="text-3xl font-bold text-text-dark mt-3 tracking-tight">{t("heading")}</h2>
-      <p className="text-text mt-4 leading-relaxed">{t("description")}</p>
+  useEffect(() => {
+    if (!hasCalendly) return;
+    if (isLoaded) return;
+    const timer = setTimeout(() => setTimedOut(true), LOAD_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [hasCalendly, isLoaded]);
 
+  return (
+    <div>
       {hasCalendly ? (
-        <div className="mt-8 rounded-2xl overflow-hidden border border-secondary/20 bg-background-alt">
-          <iframe
-            ref={iframeRef}
-            src={calendlyUrl}
-            title="Calendly booking"
-            className="w-full"
-            style={{ height: iframeHeight }}
-            loading="lazy"
-            allow="camera; microphone; autoplay; fullscreen; display-capture"
-            referrerPolicy="no-referrer-when-downgrade"
-            sandbox="allow-scripts allow-forms allow-popups"
-          />
+        <div ref={containerCallbackRef} className="relative" style={{ minHeight: iframeHeight }}>
+          {!isLoaded && (
+            <div className="absolute inset-0 z-10 flex flex-col p-6 sm:p-8">
+              <CalendlySkeleton />
+            </div>
+          )}
+          {embedUrl && (
+            <iframe
+              ref={iframeRef}
+              src={embedUrl}
+              title="Calendly booking"
+              loading="lazy"
+              className="w-full transition-all duration-500"
+              style={{
+                height: iframeHeight,
+                opacity: isLoaded ? 1 : 0,
+              }}
+              onLoad={() => setIsLoaded(true)}
+              allow="camera; microphone; autoplay; fullscreen; display-capture"
+              referrerPolicy="no-referrer-when-downgrade"
+              sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"
+            />
+          )}
+          {timedOut && !isLoaded && (
+            <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-background-alt/90 backdrop-blur-sm p-8">
+              <button
+                type="button"
+                onClick={() => {
+                  setTimedOut(false);
+                  setIsLoaded(false);
+                  const iframe = iframeRef.current;
+                  if (iframe) {
+                    iframe.src = embedUrl;
+                  }
+                }}
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-primary/10 text-primary text-sm font-semibold hover:bg-primary/20 transition-colors duration-300"
+              >
+                {t("openCalendar")}
+              </button>
+            </div>
+          )}
         </div>
       ) : (
-        <div className="mt-8 rounded-2xl border border-dashed border-secondary/30 bg-background-alt p-8 flex flex-col justify-center items-start gap-4 min-h-[320px]">
+        <div className="p-8 flex flex-col justify-center items-start gap-4 min-h-[320px]">
           <p className="text-text leading-relaxed">{t("placeholderText")}</p>
           <p className="text-text-light text-sm leading-relaxed">{t("configHint")}</p>
         </div>

--- a/src/messages/ca.json
+++ b/src/messages/ca.json
@@ -311,10 +311,6 @@
     "heading": "També em pots trobar a"
   },
   "CalendlyBookingCard": {
-    "label": "Reserva directa",
-    "heading": "Reserva una trucada",
-    "description": "Si prefereixes triar hora directament, pots reservar una cita des del calendari.",
-    "loadDescription": "Carrega el calendari per triar dia i hora de la teva cita.",
     "openCalendar": "Obrir calendari",
     "placeholderText": "El bloc de reserva estarà disponible quan es configuri la URL pública de Calendly.",
     "configHint": "Configuració requerida: NEXT_PUBLIC_CALENDLY_URL"

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -311,10 +311,6 @@
     "heading": "También puedes encontrarme en"
   },
   "CalendlyBookingCard": {
-    "label": "Reserva directa",
-    "heading": "Reserva una llamada",
-    "description": "Si prefieres elegir hora directamente, puedes reservar una cita desde el calendario.",
-    "loadDescription": "Carga el calendario para elegir día y hora de tu cita.",
     "openCalendar": "Abrir calendario",
     "placeholderText": "El bloque de reserva estará disponible en cuanto se configure la URL pública de Calendly.",
     "configHint": "Configuración requerida: NEXT_PUBLIC_CALENDLY_URL"

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
+import { buildContentSecurityPolicy } from "../config/content-security-policy";
 import { routing } from "./i18n/routing";
 
 const intlMiddleware = createMiddleware(routing);
@@ -27,6 +28,31 @@ function getUnauthorizedResponse(): NextResponse {
       "X-Robots-Tag": "noindex, nofollow",
     },
   });
+}
+
+/**
+ * Generate a per-request nonce and attach the CSP header to the response.
+ *
+ * Next.js reads the nonce from the CSP response header and auto-applies it
+ * to every inline script it injects (hydration, flight data) and to all
+ * `next/script` components (GTM, Cookiebot). No manual nonce passing needed.
+ *
+ * Staging uses Content-Security-Policy-Report-Only so violations are logged
+ * to the console without breaking the page — useful for testing CSP changes
+ * before they reach production.
+ */
+function withCsp(request: NextRequest, response: NextResponse): NextResponse {
+  const isDev = process.env.NODE_ENV === "development";
+  const staging = isStaging(request);
+  const nonce = btoa(crypto.randomUUID());
+
+  const csp = buildContentSecurityPolicy({ nonce, isDev });
+
+  const headerName =
+    staging && !isDev ? "Content-Security-Policy-Report-Only" : "Content-Security-Policy";
+
+  response.headers.set(headerName, csp);
+  return response;
 }
 
 export function proxy(request: NextRequest) {
@@ -57,7 +83,7 @@ export function proxy(request: NextRequest) {
       ) {
         const response = intlMiddleware(request);
         response.headers.set("X-Robots-Tag", "noindex, nofollow");
-        return response;
+        return withCsp(request, response);
       }
     } catch {
       // Malformed auth header
@@ -94,7 +120,8 @@ export function proxy(request: NextRequest) {
   }
 
   // === INTL MIDDLEWARE ===
-  return intlMiddleware(request);
+  const response = intlMiddleware(request);
+  return withCsp(request, response);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Three independent improvements bundled in one PR:

### 1. Calendly embed (`4d06ded`)
- Remove duplicate `<h2>` heading from card (ContactFormSection owns it)
- Document harmless cross-origin Calendly vendor script warning
- Add `loading=lazy` to iframe, preconnect/dns-prefetch hints in `<head>`
- Use callback ref for ResizeObserver with proper disconnect cleanup
- `useSyncExternalStore` for SSR-safe `embedUrl` (avoids hydration mismatch)
- Memoize `embedUrl` build to avoid `new URL` allocation per snapshot read
- Guard 8s timeout when Calendly is not configured
- Suppress react-doctor `iframe-missing-sandbox` false positive (`allow-same-origin` required for Calendly cookies)
- Remove unused i18n keys: `label`, `heading`, `description`, `loadDescription`

### 2. CSP origins refactor (`f3ec7ae`)
- Group all CSP origins by service (cookiebot, gtm, ga4, googleAds, calendly, resend, vercelInsights) — easy to audit at a glance
- Add Google Ads origins for future ad campaigns:
  - `www.googleadservices.com` (script, img, frame)
  - `googleads.g.doubleclick.net` (script, img, connect, frame)
  - `www.google.com` (img, frame for conversion linker)

### 3. CSP per-request nonces (`0951b15`)
- Move CSP from static `next.config.ts` headers to middleware (`proxy.ts`) so each request gets a unique nonce
- Next.js reads the nonce from the CSP response header and auto-applies it to all inline scripts + `next/script` components (GTM, Cookiebot) — no layout changes needed
- **Production:** `script-src 'self' 'nonce-XXX' 'strict-dynamic'` — drops `'unsafe-inline'` and `'unsafe-eval'` from script-src, closing the XSS hole
- **Dev:** `script-src 'self' 'unsafe-inline' 'unsafe-eval'` (HMR, source maps)
- **Staging:** `Content-Security-Policy-Report-Only` header (violations logged, not blocked)
- Add CSP token constants (`SELF`, `NONE`, `UNSAFE_INLINE`, etc.) for typo safety
- Other security headers (HSTS, X-Frame-Options, etc.) stay in `headers.ts`

## Test plan
- [ ] `pnpm run lint` passes
- [ ] `pnpm exec tsc --noEmit` passes
- [ ] Dev server runs without CSP errors
- [ ] Calendly iframe loads on `/contact` page
- [ ] GTM fires on production preview
- [ ] Cookiebot consent banner renders
- [ ] Staging shows CSP violations in console (report-only) but page works
- [ ] Production blocks inline scripts without nonce (check no console errors)