### PR TITLE
feat(ui): add Button, CTAButton, NavLink, SocialLink primitives with data-track analytics

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useEffect } from "react";
+import Button from "@/components/ui/Button";
 
 type Props = {
   error: Error & { digest?: string };
@@ -38,13 +39,7 @@ export default function LocaleError({ error, reset }: Props) {
         {t("title")}
       </h1>
       <p className="text-text-light text-lg max-w-md mb-8">{t("description")}</p>
-      <button
-        type="button"
-        onClick={reset}
-        className="bg-secondary text-text-dark dark:text-[#0f172a] font-bold rounded-full px-8 py-4 hover:shadow-glow transition-all"
-      >
-        {t("retry")}
-      </button>
+      <Button onClick={reset}>{t("retry")}</Button>
     </main>
   );
 }

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
+import CTAButton from "@/components/ui/CTAButton";
 import { routing } from "@/i18n/routing";
 
 export default async function LocaleNotFound() {
@@ -12,12 +12,9 @@ export default async function LocaleNotFound() {
         {t("title")}
       </h1>
       <p className="text-text-light text-lg max-w-md mb-8">{t("description")}</p>
-      <Link
-        href="/"
-        className="bg-secondary text-text-dark dark:text-[#0f172a] font-bold rounded-full px-8 py-4 hover:shadow-glow transition-all"
-      >
+      <CTAButton href="/" location="not-found">
         {t("goHome")}
-      </Link>
+      </CTAButton>
     </main>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Button from "@/components/ui/Button";
+
 export default function GlobalError({
   reset,
 }: {
@@ -31,13 +33,7 @@ export default function GlobalError({
         <p className="text-text-light text-lg max-w-md mb-8">
           Ha ocurrido un error inesperado. Por favor, intentalo de nuevo.
         </p>
-        <button
-          type="button"
-          onClick={reset}
-          className="bg-secondary text-text-dark dark:text-[#0f172a] font-bold rounded-full px-8 py-4 hover:shadow-glow transition-all"
-        >
-          Intentar de nuevo
-        </button>
+        <Button onClick={reset}>Intentar de nuevo</Button>
       </body>
     </html>
   );

--- a/src/components/about/AboutBioSection.tsx
+++ b/src/components/about/AboutBioSection.tsx
@@ -2,8 +2,8 @@
 
 import { domAnimation, LazyMotion, m } from "framer-motion";
 import Image from "next/image";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
+import CTAButton from "@/components/ui/CTAButton";
 import { images } from "@/config/images";
 
 export default function AboutBioSection() {
@@ -60,12 +60,9 @@ export default function AboutBioSection() {
               </div>
 
               <div className="mt-8 text-center">
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-                >
+                <CTAButton href="/contact" location="about-bio">
                   {t("cta")}
-                </Link>
+                </CTAButton>
               </div>
             </m.div>
           </div>

--- a/src/components/about/AboutCtaSection.tsx
+++ b/src/components/about/AboutCtaSection.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 import AnimatedSection from "@/components/composables/AnimatedSection";
+import CTAButton from "@/components/ui/CTAButton";
 
 export default async function AboutCtaSection() {
   const t = await getTranslations("AboutCtaSection");
@@ -16,12 +16,9 @@ export default async function AboutCtaSection() {
           </h2>
           <p className="mt-8 text-xl text-text-light max-w-xl mx-auto">{t("subtitle")}</p>
           <div className="mt-10">
-            <Link
-              href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
-            >
+            <CTAButton href="/contact" size="lg" location="about-cta">
               {t("cta")}
-            </Link>
+            </CTAButton>
           </div>
           <p className="mt-4 text-text-dark opacity-30 text-sm">{t("finePrint")}</p>
         </AnimatedSection>

--- a/src/components/about/AboutHeroSection.tsx
+++ b/src/components/about/AboutHeroSection.tsx
@@ -2,10 +2,10 @@
 
 import { domAnimation, LazyMotion, m } from "framer-motion";
 import Image from "next/image";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import SectionLabel from "@/components/composables/SectionLabel";
 import { fadeInUp, staggerContainer } from "@/components/home/animations";
+import CTAButton from "@/components/ui/CTAButton";
 import { images } from "@/config/images";
 
 export default function AboutHeroSection() {
@@ -38,12 +38,9 @@ export default function AboutHeroSection() {
               </m.h1>
 
               <m.div variants={fadeInUp} className="mt-10 text-center">
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-                >
+                <CTAButton href="/contact" location="about-hero">
                   {t("cta")}
-                </Link>
+                </CTAButton>
               </m.div>
             </m.div>
 

--- a/src/components/about/AboutWhySection.tsx
+++ b/src/components/about/AboutWhySection.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import AnimatedSection from "@/components/composables/AnimatedSection";
 import SectionLabel from "@/components/composables/SectionLabel";
+import CTAButton from "@/components/ui/CTAButton";
 
 export default async function AboutWhySection() {
   const t = await getTranslations("AboutWhySection");
@@ -27,12 +27,9 @@ export default async function AboutWhySection() {
               <p className="text-lg text-text leading-relaxed">{t("paragraph3")}</p>
               <p className="text-lg text-text-dark font-bold leading-relaxed">{t("highlight")}</p>
               <div className="mt-8 text-center">
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-                >
+                <CTAButton href="/contact" location="about-why">
                   {t("cta")}
-                </Link>
+                </CTAButton>
               </div>
             </div>
           </AnimatedSection>

--- a/src/components/contact/ContactSocialSection.tsx
+++ b/src/components/contact/ContactSocialSection.tsx
@@ -46,6 +46,9 @@ export default function ContactSocialSection() {
                   target={social.link.startsWith("mailto") ? undefined : "_blank"}
                   rel={social.link.startsWith("mailto") ? undefined : "noopener noreferrer"}
                   variants={fadeInUp}
+                  data-track="social"
+                  data-track-location="contact-social"
+                  data-track-label={social.name}
                   className="group bg-background-alt border border-border rounded-2xl p-8 text-center hover:border-secondary/30 hover:-translate-y-2 hover:shadow-glow transition-all duration-500"
                 >
                   <div className="w-14 h-14 rounded-2xl bg-secondary/10 flex items-center justify-center mx-auto mb-6 group-hover:bg-secondary/15 transition-colors duration-300">

--- a/src/components/core/CalendlyBookingCard.tsx
+++ b/src/components/core/CalendlyBookingCard.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { clientEnv } from "@/config/client-env.config";
+import { trackEvent } from "@/lib/tracking";
 
 const calendlyBaseUrl = clientEnv.NEXT_PUBLIC_CALENDLY_URL;
 
@@ -104,7 +105,7 @@ const CalendlyBookingCard = () => {
       }
 
       if (e.data.event === "calendly.event_scheduled") {
-        window.dataLayer?.push({ event: "calendly_scheduled" });
+        trackEvent({ event: "calendly_scheduled" });
       }
     };
 

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
+import CTAButton from "@/components/ui/CTAButton";
+import SocialLink from "@/components/ui/SocialLink";
 import { navRoutes } from "@/config/routes";
 import { email, phone, socialMediaLinksFooter } from "@/utils/data";
 import { EnvelopeIcon, WhatsappIcon } from "../composables/Icons";
@@ -57,18 +59,14 @@ const Footer = async () => {
               {socialMediaLinksFooter.map((social) => {
                 const Icon = social.Icon;
                 return (
-                  <a
+                  <SocialLink
                     key={social.name}
                     href={social.link}
-                    target={social.link.startsWith("mailto") ? undefined : "_blank"}
-                    rel={social.link.startsWith("mailto") ? undefined : "noopener noreferrer"}
-                    className="w-10 h-10 rounded-xl bg-card border border-border flex items-center justify-center
-                             hover:bg-secondary/10 hover:border-secondary/20 hover:text-primary
-                             text-text-dark opacity-40 hover:opacity-100 transition-all duration-300"
-                    aria-label={social.name}
+                    label={social.name}
+                    location="footer"
                   >
                     <Icon className="w-4 h-4" />
-                  </a>
+                  </SocialLink>
                 );
               })}
             </div>
@@ -80,13 +78,17 @@ const Footer = async () => {
             </h3>
             <ul className="space-y-3">
               {navItems.map((item) => {
+                const label = tn(item.labelKey);
                 return (
                   <li key={item.href}>
                     <Link
                       href={item.href}
+                      data-track="nav"
+                      data-track-location="footer"
+                      data-track-label={label}
                       className="text-text-inverse opacity-40 hover:opacity-100 hover:text-primary text-sm transition-all duration-300"
                     >
-                      {tn(item.labelKey)}
+                      {label}
                     </Link>
                   </li>
                 );
@@ -101,12 +103,9 @@ const Footer = async () => {
             <p className="text-text-inverse opacity-40 text-sm leading-relaxed mb-6">
               {t("ctaText")}
             </p>
-            <Link
-              href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] text-sm font-bold px-6 py-3 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-            >
+            <CTAButton href="/contact" size="sm" location="footer">
               {t("ctaButton")}
-            </Link>
+            </CTAButton>
           </div>
         </div>
 

--- a/src/components/core/NavBar.tsx
+++ b/src/components/core/NavBar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { useTheme } from "@/components/core/ThemeProvider";
+import CTAButton from "@/components/ui/CTAButton";
+import NavLink from "@/components/ui/NavLink";
 import { navRoutes } from "@/config/routes";
-import { useRouter } from "@/i18n/routing";
+import { Link, useRouter } from "@/i18n/routing";
 import { BarsIcon, CrossIcon } from "../composables/Icons";
 
 const navItems = navRoutes.filter((r) => r.href !== "/contact");
@@ -76,15 +77,9 @@ const Navbar = () => {
             <div className="hidden lg:flex items-center gap-1">
               {navItems.map((item) => {
                 return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className="text-text-light px-4 py-2 text-sm font-medium tracking-wide
-                             hover:text-text-dark hover:bg-card-hover rounded-lg
-                             transition-all duration-300"
-                  >
+                  <NavLink key={item.href} href={item.href}>
                     {t(item.labelKey)}
-                  </Link>
+                  </NavLink>
                 );
               })}
 
@@ -140,21 +135,15 @@ const Navbar = () => {
                 {otherLocale}
               </button>
 
-              <Link
-                href="/contact"
-                className="ml-4 inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-sm font-bold px-5 py-2.5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-              >
+              <CTAButton href="/contact" size="sm" location="navbar" className="ml-4">
                 {t("ctaDesktop")}
-              </Link>
+              </CTAButton>
             </div>
 
             <div className="flex items-center gap-3 lg:hidden">
-              <Link
-                href="/contact"
-                className="inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-xs font-bold px-3 py-2 rounded-full whitespace-nowrap hover:bg-secondary-light transition-all duration-300"
-              >
+              <CTAButton href="/contact" size="xs" location="mobile-nav-bar">
                 {t("ctaMobile")}
-              </Link>
+              </CTAButton>
 
               <button
                 type="button"
@@ -188,16 +177,15 @@ const Navbar = () => {
 
           {navItems.map((item, index) => {
             return (
-              <div key={item.href}>
-                <Link
-                  href={item.href}
-                  onClick={() => setIsMenuOpen(false)}
-                  className="text-2xl font-bold text-text-dark opacity-80 hover:opacity-100 transition-all duration-300"
-                  style={{ transitionDelay: `${(index + 1) * 50}ms` }}
-                >
-                  {t(item.labelKey)}
-                </Link>
-              </div>
+              <NavLink
+                key={item.href}
+                href={item.href}
+                mobile
+                onClick={() => setIsMenuOpen(false)}
+                style={{ transitionDelay: `${(index + 1) * 50}ms` }}
+              >
+                {t(item.labelKey)}
+              </NavLink>
             );
           })}
 
@@ -253,13 +241,14 @@ const Navbar = () => {
             {otherLocale}
           </button>
 
-          <Link
+          <CTAButton
             href="/contact"
+            location="mobile-nav"
             onClick={() => setIsMenuOpen(false)}
-            className="mt-4 inline-flex items-center justify-center bg-secondary text-text-dark dark:text-[#0f172a] text-base font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow transition-all duration-300"
+            className="mt-4"
           >
             {t("ctaDesktop")}
-          </Link>
+          </CTAButton>
         </div>
       </div>
     </>

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -2,9 +2,9 @@
 
 import { domAnimation, LazyMotion, m } from "framer-motion";
 import Image from "next/image";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import SectionLabel from "@/components/composables/SectionLabel";
+import CTAButton from "@/components/ui/CTAButton";
 import { images } from "@/config/images";
 
 export default function AboutSection() {
@@ -63,12 +63,9 @@ export default function AboutSection() {
               </div>
 
               <div className="mt-8 text-center">
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-                >
+                <CTAButton href="/contact" location="home-about">
                   {t("cta")}
-                </Link>
+                </CTAButton>
               </div>
             </m.div>
           </div>

--- a/src/components/home/BenefitsSection.tsx
+++ b/src/components/home/BenefitsSection.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { domAnimation, LazyMotion, m } from "framer-motion";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import AnimatedSection from "@/components/composables/AnimatedSection";
 import CheckIcon from "@/components/composables/CheckIcon";
 import SectionLabel from "@/components/composables/SectionLabel";
 import { fadeInUp, staggerContainer } from "@/components/home/animations";
+import CTAButton from "@/components/ui/CTAButton";
 
 export default function BenefitsSection() {
   const t = useTranslations("BenefitsSection");
@@ -27,12 +27,9 @@ export default function BenefitsSection() {
                 {t("subtitle")}
               </p>
               <div className="mt-10 text-center">
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-primary-dark text-text-inverse font-semibold px-8 py-4 rounded-full hover:bg-secondary hover:text-text-dark dark:hover:text-[#0f172a] hover:shadow-glow transition-all duration-300"
-                >
+                <CTAButton href="/contact" location="benefits" variant="secondary">
                   {t("cta")}
-                </Link>
+                </CTAButton>
               </div>
             </AnimatedSection>
 

--- a/src/components/home/FinalCtaSection.tsx
+++ b/src/components/home/FinalCtaSection.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 import AnimatedSection from "@/components/composables/AnimatedSection";
+import CTAButton from "@/components/ui/CTAButton";
 
 export default async function FinalCtaSection() {
   const t = await getTranslations("FinalCtaSection");
@@ -16,12 +16,9 @@ export default async function FinalCtaSection() {
           </h2>
           <p className="mt-8 text-xl text-text-light max-w-xl mx-auto">{t("subtitle")}</p>
           <div className="mt-10">
-            <Link
-              href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
-            >
+            <CTAButton href="/contact" size="lg" location="final-cta">
               {t("cta")}
-            </Link>
+            </CTAButton>
           </div>
           <p className="mt-4 text-text-dark opacity-30 text-sm">{t("finePrint")}</p>
         </AnimatedSection>

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -2,11 +2,11 @@
 
 import { domAnimation, LazyMotion, m } from "framer-motion";
 import Image from "next/image";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import CheckIcon from "@/components/composables/CheckIcon";
 import SectionLabel from "@/components/composables/SectionLabel";
 import { fadeInUp, staggerContainer } from "@/components/home/animations";
+import CTAButton from "@/components/ui/CTAButton";
 import { images } from "@/config/images";
 import { getYearsOfExperience } from "@/utils/experience";
 
@@ -97,12 +97,9 @@ export default function HeroSection() {
                 variants={fadeInUp}
                 className="mt-10 flex flex-col sm:flex-row gap-4 items-center justify-center"
               >
-                <Link
-                  href="/contact"
-                  className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-                >
+                <CTAButton href="/contact" location="hero">
                   {t("ctaPrimary")}
-                </Link>
+                </CTAButton>
               </m.div>
 
               <m.div

--- a/src/components/servicios/ServiciosCtaSection.tsx
+++ b/src/components/servicios/ServiciosCtaSection.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 import AnimatedSection from "@/components/composables/AnimatedSection";
+import CTAButton from "@/components/ui/CTAButton";
 
 export default async function ServiciosCtaSection() {
   const t = await getTranslations("ServiciosCtaSection");
@@ -15,12 +15,9 @@ export default async function ServiciosCtaSection() {
             {t("heading")}
           </h2>
           <div className="mt-10">
-            <Link
-              href="/contact"
-              className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] text-lg font-bold px-10 py-5 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-1 transition-all duration-300"
-            >
+            <CTAButton href="/contact" size="lg" location="servicios-cta">
               {t("cta")}
-            </Link>
+            </CTAButton>
           </div>
           <p className="mt-4 text-text-dark opacity-30 text-sm">{t("finePrint")}</p>
         </AnimatedSection>

--- a/src/components/servicios/ServiciosHeroSection.tsx
+++ b/src/components/servicios/ServiciosHeroSection.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { domAnimation, LazyMotion, m } from "framer-motion";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import SectionLabel from "@/components/composables/SectionLabel";
 import { fadeInUp, staggerContainer } from "@/components/home/animations";
+import CTAButton from "@/components/ui/CTAButton";
 
 export default function ServiciosHeroSection() {
   const t = useTranslations("ServiciosHeroSection");
@@ -43,12 +43,9 @@ export default function ServiciosHeroSection() {
             </m.p>
 
             <m.div variants={fadeInUp} className="mt-10 text-center">
-              <Link
-                href="/contact"
-                className="inline-flex items-center justify-center text-center bg-secondary text-text-dark dark:text-[#0f172a] font-bold text-base px-8 py-4 rounded-full hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5 transition-all duration-300"
-              >
+              <CTAButton href="/contact" location="servicios-hero">
                 {t("cta")}
-              </Link>
+              </CTAButton>
             </m.div>
             <m.p variants={fadeInUp} className="mt-3 text-text-light text-sm text-center">
               {t("finePrint")}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+
+type ButtonVariant = "primary" | "secondary" | "ghost" | "outline";
+type ButtonSize = "xs" | "sm" | "md" | "lg";
+type ButtonShape = "pill" | "rounded";
+
+export type ButtonProps = {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  shape?: ButtonShape;
+  href?: string;
+  track?: string;
+  trackLocation?: string;
+  trackLabel?: string;
+  className?: string;
+  children: React.ReactNode;
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
+  target?: string;
+  rel?: string;
+  onClick?: () => void;
+  style?: React.CSSProperties;
+  "aria-label"?: string;
+};
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    "bg-secondary text-text-dark dark:text-[#0f172a] font-bold hover:bg-secondary-light hover:shadow-glow hover:-translate-y-0.5",
+  secondary:
+    "bg-primary-dark text-text-inverse font-bold hover:bg-secondary hover:text-text-dark dark:hover:text-[#0f172a] hover:shadow-glow",
+  ghost: "text-text-light font-medium tracking-wide hover:text-text-dark hover:bg-card-hover",
+  outline:
+    "border border-border text-text-light font-semibold uppercase tracking-widest hover:text-primary hover:bg-card-hover",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  xs: "px-3 py-2 text-xs",
+  sm: "px-5 py-2.5 text-sm",
+  md: "px-8 py-4 text-base",
+  lg: "px-10 py-5 text-lg",
+};
+
+const shapeStyles: Record<ButtonShape, string> = {
+  pill: "rounded-full",
+  rounded: "rounded-lg",
+};
+
+const baseStyles =
+  "inline-flex items-center justify-center text-center transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:opacity-50 disabled:pointer-events-none";
+
+export function buildDataAttrs(track?: string, trackLocation?: string, trackLabel?: string) {
+  const attrs: Record<string, string | undefined> = {};
+  if (track) attrs["data-track"] = track;
+  if (trackLocation) attrs["data-track-location"] = trackLocation;
+  if (trackLabel) attrs["data-track-label"] = trackLabel;
+  return attrs as Record<string, string>;
+}
+
+export default function Button({
+  variant = "primary",
+  size = "md",
+  shape = "pill",
+  href,
+  track,
+  trackLocation,
+  trackLabel,
+  className = "",
+  children,
+  type = "button",
+  disabled,
+  target,
+  rel,
+  onClick,
+  style,
+  ...rest
+}: ButtonProps & Record<string, unknown>) {
+  const classes = [
+    baseStyles,
+    variantStyles[variant],
+    sizeStyles[size],
+    shapeStyles[shape],
+    className,
+  ].join(" ");
+
+  const dataAttrs = buildDataAttrs(track, trackLocation, trackLabel);
+
+  if (href) {
+    if (href.startsWith("/")) {
+      return (
+        <Link
+          href={href}
+          className={classes}
+          onClick={onClick}
+          style={style}
+          {...dataAttrs}
+          {...rest}
+        >
+          {children}
+        </Link>
+      );
+    }
+    return (
+      <a
+        href={href}
+        target={target}
+        rel={rel}
+        className={classes}
+        onClick={onClick}
+        style={style}
+        {...dataAttrs}
+        {...rest}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      className={classes}
+      onClick={onClick}
+      style={style}
+      {...dataAttrs}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/CTAButton.tsx
+++ b/src/components/ui/CTAButton.tsx
@@ -1,0 +1,39 @@
+import Button from "@/components/ui/Button";
+
+type CTAButtonProps = {
+  href: string;
+  size?: "xs" | "sm" | "md" | "lg";
+  variant?: "primary" | "secondary";
+  location: string;
+  label?: string;
+  className?: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+};
+
+export default function CTAButton({
+  href,
+  size = "md",
+  variant = "primary",
+  location,
+  label,
+  className = "",
+  children,
+  onClick,
+}: CTAButtonProps) {
+  return (
+    <Button
+      href={href}
+      variant={variant}
+      size={size}
+      shape="pill"
+      track="cta"
+      trackLocation={location}
+      trackLabel={label}
+      className={className}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/ui/NavLink.tsx
+++ b/src/components/ui/NavLink.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Button from "@/components/ui/Button";
+import { usePathname } from "@/i18n/routing";
+
+type NavLinkProps = {
+  href: string;
+  children: React.ReactNode;
+  mobile?: boolean;
+  location?: string;
+  onClick?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export default function NavLink({
+  href,
+  children,
+  mobile = false,
+  location = "navbar",
+  onClick,
+  className = "",
+  style,
+}: NavLinkProps) {
+  const pathname = usePathname();
+  const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
+
+  const activeClasses = isActive
+    ? "bg-card-hover text-text-dark font-medium"
+    : "text-text-light hover:text-text-dark hover:bg-card-hover";
+
+  return (
+    <Button
+      href={href}
+      variant="ghost"
+      size={mobile ? "md" : "sm"}
+      shape="rounded"
+      track="nav"
+      trackLocation={mobile ? "mobile-nav" : location}
+      trackLabel={typeof children === "string" ? children : undefined}
+      className={`${activeClasses} ${mobile ? "w-full text-center text-2xl font-bold opacity-80 hover:opacity-100" : ""} ${className}`}
+      onClick={onClick}
+      style={style}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/ui/SocialLink.tsx
+++ b/src/components/ui/SocialLink.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+type SocialLinkProps = {
+  href: string;
+  label: string;
+  children: ReactNode;
+  className?: string;
+  location?: string;
+};
+
+export default function SocialLink({
+  href,
+  label,
+  children,
+  className = "",
+  location = "footer",
+}: SocialLinkProps) {
+  const isExternal = href.startsWith("http") || href.startsWith("mailto") || href.startsWith("tel");
+
+  const classes = [
+    "w-10 h-10 rounded-xl bg-card border border-border flex items-center justify-center",
+    "hover:bg-secondary/10 hover:border-secondary/20 hover:text-primary",
+    "text-text-dark opacity-40 hover:opacity-100 transition-all duration-300",
+    className,
+  ].join(" ");
+
+  const dataAttrs: Record<string, string> = {
+    "data-track": "social",
+    "data-track-location": location,
+    "data-track-label": label,
+  };
+
+  if (isExternal) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={classes}
+        aria-label={label}
+        {...dataAttrs}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a href={href} className={classes} aria-label={label} {...dataAttrs}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/ui/__tests__/tracking.test.ts
+++ b/src/components/ui/__tests__/tracking.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDataAttrs } from "@/components/ui/Button";
+import { trackEvent } from "@/lib/tracking";
+
+describe("buildDataAttrs", () => {
+  it("returns empty object when no tracking props are given", () => {
+    expect(buildDataAttrs()).toEqual({});
+  });
+
+  it("emits data-track only when track is provided", () => {
+    expect(buildDataAttrs("cta")).toEqual({ "data-track": "cta" });
+  });
+
+  it("emits location and label alongside track", () => {
+    expect(buildDataAttrs("nav", "navbar", "Home")).toEqual({
+      "data-track": "nav",
+      "data-track-location": "navbar",
+      "data-track-label": "Home",
+    });
+  });
+
+  it("omits location and label when undefined", () => {
+    expect(buildDataAttrs("cta", undefined, undefined)).toEqual({
+      "data-track": "cta",
+    });
+  });
+
+  it("emits track and location without label", () => {
+    expect(buildDataAttrs("social", "footer")).toEqual({
+      "data-track": "social",
+      "data-track-location": "footer",
+    });
+  });
+});
+
+describe("trackEvent", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("pushes the event onto window.dataLayer when present", () => {
+    const dataLayer: unknown[] = [];
+    vi.stubGlobal("window", { dataLayer });
+    trackEvent({ event: "calendly_scheduled" });
+    expect(dataLayer).toHaveLength(1);
+    expect(dataLayer[0]).toEqual({ event: "calendly_scheduled" });
+  });
+
+  it("is a no-op when window is undefined", () => {
+    expect(() => trackEvent({ event: "x" })).not.toThrow();
+  });
+
+  it("is a no-op when dataLayer is missing", () => {
+    vi.stubGlobal("window", {});
+    expect(() => trackEvent({ event: "x" })).not.toThrow();
+  });
+});

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -7,4 +7,4 @@ export const routing = defineRouting({
   localePrefix: "as-needed",
 });
 
-export const { useRouter } = createNavigation(routing);
+export const { Link, useRouter, usePathname } = createNavigation(routing);

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,0 +1,12 @@
+export type TrackEvent = {
+  event: string;
+  label?: string;
+  location?: string;
+  [key: string]: unknown;
+};
+
+export function trackEvent(e: TrackEvent): void {
+  if (typeof window !== "undefined" && window.dataLayer) {
+    window.dataLayer.push(e);
+  }
+}

--- a/src/types/gtm.d.ts
+++ b/src/types/gtm.d.ts
@@ -1,11 +1,13 @@
 type DataLayerEvent = {
-  event: "generate_lead" | "calendly_scheduled";
+  event: string;
+  label?: string;
+  location?: string;
   leadSource?: string;
 };
 
 declare global {
   interface Window {
-    dataLayer: Array<DataLayerEvent>;
+    dataLayer: DataLayerEvent[];
   }
 }
 


### PR DESCRIPTION

## Summary

Add a family of reusable button/link UI primitives that emit stable `data-track*` attributes for GTM-triggered GA4 events. Migrate all ~17 call sites (navbar, footer, error pages, home/about/servicios sections, contact social cards) to use the new components.

## Changes

### feat(ui): add Button, CTAButton, NavLink, SocialLink primitives with data-track attrs

- **Button**: renders `Link`/`a`/`button` with optional `track`/`trackLocation`/`trackLabel` props that emit `data-track`, `data-track-location`, `data-track-label`
- **CTAButton**: wraps Button with `track="cta"`
- **NavLink**: wraps Button with `track="nav"`, active-state styling, auto-switch navbar→mobile-nav
- **SocialLink**: standalone component emitting `data-track="social"`
- **tracking.ts**: `trackEvent` helper that pushes to `window.dataLayer`
- **gtm.d.ts**: types `window.dataLayer` + events

### refactor: migrate CTAs, nav, and social links to new UI components

Every raw `<Link>`/`<button>`/`<a>` with CTA/nav/social styling replaced. Footer nav links now emit `data-track="nav"` with `location="footer"` (was a gap). Mobile top-bar CTA uses `mobile-nav-bar` to distinguish from drawer `mobile-nav`. CalendlyBookingCard uses `trackEvent` helper. ContactSocialSection hard-codes `data-track="social"` on framer-motion `<m.a>`.

### test: add tracking attribute contract tests

8 tests locking `buildDataAttrs` attribute contract and `trackEvent` dataLayer push/no-op behavior. No new dependencies.

## Related

Corresponding GTM/GA4 setup documented in `docs/gtm-setup.md` (local-only, gitignored).
