### PR TITLE
feat: GDPR cookie consent banner with GTM Consent Mode v2

### DIFF
--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -127,7 +127,7 @@ export function buildContentSecurityPolicy({ nonce, isDev = false }: CspOptions 
     "script-src": scriptSrc,
     "style-src": styleSrc,
     "img-src": [SELF, "data:", "blob:", ...collect("img"), ...(vercelLive.img ?? [])],
-    "font-src": [SELF, ...(vercelLive.font ?? [])],
+    "font-src": [SELF, ...collect("font"), ...(vercelLive.font ?? [])],
     "connect-src": [SELF, ...collect("connect"), ...(vercelLive.connect ?? [])],
     "frame-src": [SELF, ...collect("frame"), ...(vercelLive.frame ?? [])],
     "frame-ancestors": [NONE],

--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -41,7 +41,8 @@ type ServiceOrigins = Partial<Record<DirectiveKey, string[]>>;
 const services: Record<string, ServiceOrigins> = {
   gtm: {
     script: ["https://www.googletagmanager.com"],
-    img: ["https://www.googletagmanager.com"],
+    style: ["https://www.googletagmanager.com", "https://fonts.googleapis.com"],
+    img: ["https://www.googletagmanager.com", "https://fonts.gstatic.com"],
     connect: ["https://www.googletagmanager.com"],
     frame: ["https://www.googletagmanager.com"],
   },

--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -7,8 +7,7 @@
  * ## Nonce mode (production)
  * A per-request nonce is injected via middleware. Next.js reads the nonce
  * from the CSP response header and auto-applies it to every inline script
- * it injects (hydration, flight data) and to all `next/script` components
- * (GTM, Cookiebot). `'strict-dynamic'` lets nonce'd scripts load their own
+ * it injects (hydration, flight data). `'strict-dynamic'` lets nonce'd scripts load their own
  * scripts transitively, so GTM can bootstrap without listing every child
  * script origin.
  *
@@ -40,13 +39,6 @@ type DirectiveKey = "script" | "style" | "img" | "font" | "connect" | "frame";
 type ServiceOrigins = Partial<Record<DirectiveKey, string[]>>;
 
 const services: Record<string, ServiceOrigins> = {
-  cookiebot: {
-    script: ["https://consent.cookiebot.com"],
-    style: ["https://consent.cookiebot.com"],
-    img: ["https://*.cookiebot.com"],
-    connect: ["https://consent.cookiebot.com"],
-    frame: ["https://consent.cookiebot.com"],
-  },
   gtm: {
     script: ["https://www.googletagmanager.com"],
     img: ["https://www.googletagmanager.com"],
@@ -54,9 +46,17 @@ const services: Record<string, ServiceOrigins> = {
     frame: ["https://www.googletagmanager.com"],
   },
   ga4: {
-    script: ["https://www.google-analytics.com", "https://ssl.google-analytics.com"],
-    img: ["https://www.google-analytics.com", "https://ssl.google-analytics.com"],
-    connect: ["https://*.google-analytics.com"],
+    script: [
+      "https://www.googletag.com",
+      "https://www.google-analytics.com",
+      "https://ssl.google-analytics.com",
+    ],
+    img: [
+      "https://www.googletag.com",
+      "https://www.google-analytics.com",
+      "https://ssl.google-analytics.com",
+    ],
+    connect: ["https://www.googletag.com", "https://*.google-analytics.com"],
     frame: ["https://www.google-analytics.com"],
   },
   googleAds: {

--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -43,6 +43,7 @@ const services: Record<string, ServiceOrigins> = {
     script: ["https://www.googletagmanager.com"],
     style: ["https://www.googletagmanager.com", "https://fonts.googleapis.com"],
     img: ["https://www.googletagmanager.com", "https://fonts.gstatic.com"],
+    font: ["https://fonts.gstatic.com"],
     connect: ["https://www.googletagmanager.com"],
     frame: ["https://www.googletagmanager.com"],
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "doctor": "npx react-doctor@latest"
   },
   "dependencies": {
-    "@next/third-parties": "^16.2.9",
     "@swc/helpers": "^0.5.17",
     "framer-motion": "^12.0.1",
     "next": "^16.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@next/third-parties':
-        specifier: ^16.2.9
-        version: 16.2.9(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
@@ -961,12 +958,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@next/third-parties@16.2.9':
-    resolution: {integrity: sha512-JZPGQRN8eQs2WMfBXOf6Zjrma+JIN0KyA24MvmIa3bUI4BwTaJ1UlxmYVc5ri6l30LQ8fPv6Kmx20447hCltrg==}
-    peerDependencies:
-      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2946,9 +2937,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  third-party-capital@1.0.20:
-    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
-
   third-party-web@0.29.2:
     resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
@@ -4183,12 +4171,6 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.9':
     optional: true
-
-  '@next/third-parties@16.2.9(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6123,8 +6105,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  third-party-capital@1.0.20: {}
 
   third-party-web@0.29.2: {}
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,6 @@ import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
-import { Suspense } from "react";
 import "../globals.css";
 import Footer from "@/components/core/Footer";
 import Navbar from "@/components/core/NavBar";
@@ -85,11 +84,7 @@ export default async function LocaleLayout({ children, params }: Props) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased`}
       >
-        {gtmId && (
-          <Suspense>
-            <GoogleTagManager gtmId={gtmId} />
-          </Suspense>
-        )}
+        {gtmId && <GoogleTagManager gtmId={gtmId} />}
         <Providers initialTheme={initialTheme}>
           <NextIntlClientProvider messages={messages}>
             <Navbar />

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,14 +1,15 @@
-import { GoogleTagManager } from "@next/third-parties/google";
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
-import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 import "../globals.css";
 import Footer from "@/components/core/Footer";
 import Navbar from "@/components/core/NavBar";
+import CookieBanner from "@/components/privacy/CookieBanner";
+import GoogleTagManager from "@/components/privacy/GoogleTagManager";
 import { clientEnv } from "@/config/client-env.config";
 import { routing } from "@/i18n/routing";
 import { createPageMetadata } from "../metadata";
@@ -25,17 +26,6 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
   display: "swap",
 });
-
-const CookiebotScript = ({ cbid }: { cbid: string }) => (
-  <Script
-    id="Cookiebot"
-    src="https://consent.cookiebot.com/uc.js"
-    data-cbid={cbid}
-    data-blockingmode="auto"
-    type="text/javascript"
-    strategy="lazyOnload"
-  />
-);
 
 type Props = {
   children: React.ReactNode;
@@ -70,7 +60,6 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   const messages = await getMessages();
   const gtmId = clientEnv.NEXT_PUBLIC_GTM_ID;
-  const cookiebotCbid = clientEnv.NEXT_PUBLIC_COOKIEBOT_CBID;
 
   const cookieStore = await cookies();
   const themeCookie = cookieStore.get("theme")?.value;
@@ -82,19 +71,10 @@ export default async function LocaleLayout({ children, params }: Props) {
       className={`scroll-smooth bg-background ${initialTheme === "dark" ? "dark" : ""}`}
     >
       <head>
-        {/* Preconnect to critical third-party origins for faster resource loading.
-            Place preconnect hints before any preload/resource links to ensure the
-            browser initiates TCP/TLS handshakes early. */}
         {gtmId && (
           <>
             <link rel="preconnect" href="https://www.googletagmanager.com" />
             <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-          </>
-        )}
-        {cookiebotCbid && (
-          <>
-            <link rel="preconnect" href="https://consent.cookiebot.com" />
-            <link rel="dns-prefetch" href="https://consent.cookiebot.com" />
           </>
         )}
         <link rel="preconnect" href="https://calendly.com" />
@@ -105,13 +85,17 @@ export default async function LocaleLayout({ children, params }: Props) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased`}
       >
-        {cookiebotCbid && <CookiebotScript cbid={cookiebotCbid} />}
-        {gtmId && <GoogleTagManager gtmId={gtmId} />}
+        {gtmId && (
+          <Suspense>
+            <GoogleTagManager gtmId={gtmId} />
+          </Suspense>
+        )}
         <Providers initialTheme={initialTheme}>
           <NextIntlClientProvider messages={messages}>
             <Navbar />
             <div className="flex flex-col min-h-screen flex-grow">{children}</div>
             <Footer />
+            <CookieBanner />
           </NextIntlClientProvider>
         </Providers>
       </body>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -68,6 +68,7 @@ export default async function LocaleLayout({ children, params }: Props) {
     <html
       lang={locale}
       className={`scroll-smooth bg-background ${initialTheme === "dark" ? "dark" : ""}`}
+      suppressHydrationWarning
     >
       <head>
         {gtmId && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,24 +67,34 @@ html {
   color: inherit;
 }
 
-/* Cookiebot accessibility overrides */
-#CybotCookiebotDialog .CybotCookiebotDialogBodyLevelButtonSave {
-  background-color: #1c4761 !important;
-  color: #ffffff !important;
+@keyframes cookie-banner-in {
+  from {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-#CybotCookiebotDialog a,
-#CybotCookiebotDialog .CybotCookiebotDialogBodyLevelDetailsButton {
-  font-size: 0.875rem !important;
-  padding: 0.5rem 1rem !important;
-  min-height: 44px !important;
-  display: inline-flex !important;
-  align-items: center !important;
+@keyframes cookie-banner-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(100%);
+  }
 }
 
-#CybotCookiebotDialog *:focus-visible {
-  outline: 2px solid #1c4761 !important;
-  outline-offset: 2px !important;
+.animate-cookie-banner-in {
+  animation: cookie-banner-in 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.animate-cookie-banner-out {
+  animation: cookie-banner-out 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
+import CookieSettingsLink from "@/components/privacy/CookieSettingsLink";
 import CTAButton from "@/components/ui/CTAButton";
 import SocialLink from "@/components/ui/SocialLink";
 import { navRoutes } from "@/config/routes";
@@ -122,6 +123,7 @@ const Footer = async () => {
               >
                 {t("privacyLink")}
               </Link>
+              <CookieSettingsLink />
             </div>
           </div>
         </div>

--- a/src/components/privacy/CookieBanner.tsx
+++ b/src/components/privacy/CookieBanner.tsx
@@ -24,10 +24,6 @@ function storeConsent(choice: ConsentChoice) {
   document.cookie = `${CONSENT_KEY}=${choice}; expires=${expires}; path=/; SameSite=Lax${isSecure ? "; Secure" : ""}`;
 }
 
-export function hasMarketingConsent(): boolean {
-  return getStoredConsent() === "accepted";
-}
-
 function CookieIcon({ className }: { className?: string }) {
   return (
     <svg

--- a/src/components/privacy/CookieBanner.tsx
+++ b/src/components/privacy/CookieBanner.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "@/i18n/routing";
+
+export type ConsentChoice = "accepted" | "rejected";
+
+const CONSENT_KEY = "cookie_consent";
+const CONSENT_DAYS = 365;
+const EXIT_ANIMATION_MS = 300;
+
+function getStoredConsent(): ConsentChoice | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.split("; ").find((c) => c.startsWith(`${CONSENT_KEY}=`));
+  if (!match) return null;
+  return match.split("=")[1] as ConsentChoice;
+}
+
+function storeConsent(choice: ConsentChoice) {
+  const expires = new Date(Date.now() + CONSENT_DAYS * 86400000).toUTCString();
+  const isSecure = typeof window !== "undefined" && window.location.protocol === "https:";
+  // biome-ignore lint/suspicious/noDocumentCookie: client-side consent cookie is the standard approach
+  document.cookie = `${CONSENT_KEY}=${choice}; expires=${expires}; path=/; SameSite=Lax${isSecure ? "; Secure" : ""}`;
+}
+
+export function hasMarketingConsent(): boolean {
+  return getStoredConsent() === "accepted";
+}
+
+function CookieIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 2a10 10 0 1 0 10 10c0-.46-.04-.92-.1-1.36a4 4 0 0 1-5.54-5.54A9.93 9.93 0 0 0 12 2z" />
+      <circle cx="9" cy="10" r=".8" fill="currentColor" />
+      <circle cx="14" cy="8" r=".8" fill="currentColor" />
+      <circle cx="15" cy="14" r=".8" fill="currentColor" />
+      <circle cx="10" cy="16" r=".8" fill="currentColor" />
+    </svg>
+  );
+}
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const t = useTranslations("CookieBanner");
+
+  useEffect(() => {
+    if (!getStoredConsent()) {
+      setVisible(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    function handleReopen() {
+      setClosing(false);
+      setVisible(true);
+    }
+
+    window.addEventListener("open-cookie-banner", handleReopen);
+    return () => window.removeEventListener("open-cookie-banner", handleReopen);
+  }, []);
+
+  const handleChoice = useCallback((choice: ConsentChoice) => {
+    storeConsent(choice);
+    window.dispatchEvent(new Event("consent-updated"));
+    if (choice === "accepted" && typeof window.gtag === "function") {
+      window.gtag("consent", "update", {
+        ad_storage: "granted",
+        ad_user_data: "granted",
+        ad_personalization: "granted",
+        analytics_storage: "granted",
+      });
+      window.dataLayer?.push({ event: "consent_granted" });
+    } else if (choice === "rejected" && typeof window.gtag === "function") {
+      window.gtag("consent", "update", {
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+        analytics_storage: "denied",
+      });
+    }
+    setClosing(true);
+    window.setTimeout(() => {
+      setVisible(false);
+      setClosing(false);
+    }, EXIT_ANIMATION_MS);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-50 flex items-end justify-center p-4 sm:p-6"
+      role="dialog"
+      aria-modal="false"
+      aria-label={t("ariaLabel")}
+    >
+      <div
+        ref={dialogRef}
+        className={`w-full max-w-2xl rounded-2xl border border-border bg-card shadow-2xl ${
+          closing ? "animate-cookie-banner-out" : "animate-cookie-banner-in"
+        }`}
+      >
+        <div className="flex items-start gap-4 p-5 sm:p-6">
+          <div className="hidden sm:flex shrink-0 items-center justify-center w-11 h-11 rounded-full bg-primary-light/20 text-primary">
+            <CookieIcon className="w-6 h-6" />
+          </div>
+
+          <div className="flex-1">
+            <p className="text-sm leading-relaxed text-text-light">
+              {t("message")}{" "}
+              <Link
+                href="/privacy"
+                className="text-primary underline underline-offset-2 hover:text-primary-dark transition-colors font-medium"
+              >
+                {t("privacyLink")}
+              </Link>
+            </p>
+
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => handleChoice("rejected")}
+                className="rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-text-light transition-all hover:bg-card-hover hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                {t("reject")}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleChoice("accepted")}
+                className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-text-inverse transition-all hover:bg-primary-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                {t("accept")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/privacy/CookieSettingsLink.tsx
+++ b/src/components/privacy/CookieSettingsLink.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+export default function CookieSettingsLink() {
+  const t = useTranslations("CookieBanner");
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.dispatchEvent(new Event("open-cookie-banner"))}
+      className="text-text-inverse opacity-25 hover:opacity-50 text-xs transition-all duration-300"
+    >
+      {t("settings")}
+    </button>
+  );
+}

--- a/src/components/privacy/GoogleTagManager.tsx
+++ b/src/components/privacy/GoogleTagManager.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Script from "next/script";
+
+type Props = {
+  gtmId: string;
+};
+
+export default function GoogleTagManager({ gtmId }: Props) {
+  return (
+    <>
+      <Script
+        id="gtm-consent-default"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+window.dataLayer = window.dataLayer || [];
+function gtag(){window.dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied'
+});
+if (document.cookie.indexOf('cookie_consent=accepted') !== -1) {
+  gtag('consent', 'update', {
+    'ad_storage': 'granted',
+    'ad_user_data': 'granted',
+    'ad_personalization': 'granted',
+    'analytics_storage': 'granted'
+  });
+}
+window.dataLayer.push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+`,
+        }}
+      />
+      <Script
+        id="gtm-script"
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}`}
+      />
+      <noscript>
+        <iframe
+          title="Google Tag Manager"
+          src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+          height="0"
+          width="0"
+          style={{ display: "none", visibility: "hidden" }}
+        />
+      </noscript>
+    </>
+  );
+}

--- a/src/components/privacy/PrivacyContentSection.tsx
+++ b/src/components/privacy/PrivacyContentSection.tsx
@@ -94,15 +94,14 @@ export default function PrivacyContentSection() {
         { term: "Vercel, Inc.", detail: "(alojamiento web)" },
         { term: "Resend, Inc.", detail: "(envio de correos electronicos)" },
         { term: "Google LLC", detail: "(analisis web y publicidad, solo con tu consentimiento)" },
-        { term: "Cookiebot by Usercentrics", detail: "(gestion de consentimiento de cookies)" },
       ],
     },
     {
       title: t("section6Title"),
       icon: "\uD83C\uDF6A",
       content: [
-        "Este sitio web utiliza cookies propias y de terceros para mejorar la experiencia de navegacion, analizar el trafico y personalizar la publicidad. La gestion de cookies se realiza a traves de Cookiebot, una plataforma que te permite aceptar, rechazar o configurar el uso de cookies de forma granular.",
-        "Puedes modificar tu configuracion de cookies en cualquier momento haciendo clic en el banner de consentimiento o en el icono de configuracion de cookies que aparece en la parte inferior del sitio.",
+        "Este sitio web utiliza cookies propias y de terceros para mejorar la experiencia de navegacion, analizar el trafico y personalizar la publicidad. La gestion de cookies se realiza a traves de un banner de consentimiento integrado que te permite aceptar o rechazar las cookies no esenciales.",
+        "Puedes modificar tu preferencia de cookies en cualquier momento limpiando las cookies del navegador o haciendo clic en el enlace de politica de cookies del pie de pagina.",
       ],
     },
     {

--- a/src/config/client-env.config.ts
+++ b/src/config/client-env.config.ts
@@ -9,14 +9,12 @@
 export interface ClientEnv {
   NEXT_PUBLIC_CALENDLY_URL?: string;
   NEXT_PUBLIC_GTM_ID?: string;
-  NEXT_PUBLIC_COOKIEBOT_CBID?: string;
 }
 
 function validateEnv(): ClientEnv {
   return {
     NEXT_PUBLIC_CALENDLY_URL: process.env.NEXT_PUBLIC_CALENDLY_URL?.trim() || undefined,
     NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID?.trim() || undefined,
-    NEXT_PUBLIC_COOKIEBOT_CBID: process.env.NEXT_PUBLIC_COOKIEBOT_CBID?.trim() || undefined,
   };
 }
 

--- a/src/messages/ca.json
+++ b/src/messages/ca.json
@@ -330,7 +330,7 @@
     "section4Title": "4. Conservació de les dades",
     "section4Desc": "Conservem les teves dades durant el temps necessari per complir amb la finalitat per a la qual es van recollir i per complir amb obligacions legals.",
     "section5Title": "5. Destinataris de les dades",
-    "section5Desc": "Les teves dades poden ser compartides amb: Vercel (allotjament web), Resend (servei de correu electrònic), Google LLC (analítica), Cookiebot (gestió de consentiment de cookies). No realitzem transferències internacionals de dades.",
+    "section5Desc": "Les teves dades poden ser compartides amb: Vercel (allotjament web), Resend (servei de correu electrònic), Google LLC (analítica). No realitzem transferències internacionals de dades.",
     "section6Title": "6. Cookies",
     "section6Desc": "Utilitzem cookies tècniques necessàries per al funcionament del lloc i cookies d'anàlisi per entendre com s'utilitza el lloc. Pots gestionar les teves preferències de cookies en qualsevol moment.",
     "section7Title": "7. Drets dels usuaris",
@@ -425,5 +425,13 @@
     "title": "Pàgina no trobada",
     "description": "La pàgina que busques no existeix o ha estat moguda.",
     "goHome": "Tornar a l'inici"
+  },
+  "CookieBanner": {
+    "ariaLabel": "Consentiment de cookies",
+    "message": "Utilitzem cookies pròpies i de tercers per millorar la teva experiència i analitzar el trànsit del lloc web.",
+    "accept": "Acceptar totes",
+    "reject": "Només essencials",
+    "privacyLink": "Política de cookies",
+    "settings": "Configuració de cookies"
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -330,7 +330,7 @@
     "section4Title": "4. Conservación de los datos",
     "section4Desc": "Conservamos tus datos durante el tiempo necesario para cumplir con la finalidad para la que se recogieron y para cumplir con obligaciones legales.",
     "section5Title": "5. Destinatarios de los datos",
-    "section5Desc": "Tus datos pueden ser compartidos con: Vercel (alojamiento web), Resend (servicio de correo electrónico), Google LLC (analítica), Cookiebot (gestión de consentimiento de cookies). No realizamos transferencias internacionales de datos.",
+    "section5Desc": "Tus datos pueden ser compartidos con: Vercel (alojamiento web), Resend (servicio de correo electrónico), Google LLC (analítica). No realizamos transferencias internacionales de datos.",
     "section6Title": "6. Cookies",
     "section6Desc": "Utilizamos cookies técnicas necesarias para el funcionamiento del sitio y cookies de análisis para entender cómo se utiliza el sitio. Puedes gestionar tus preferencias de cookies en cualquier momento.",
     "section7Title": "7. Derechos de los usuarios",
@@ -425,5 +425,13 @@
     "title": "Página no encontrada",
     "description": "La página que buscas no existe o ha sido movida.",
     "goHome": "Volver al inicio"
+  },
+  "CookieBanner": {
+    "ariaLabel": "Consentimiento de cookies",
+    "message": "Utilizamos cookies propias y de terceros para mejorar tu experiencia y analizar el tráfico del sitio.",
+    "accept": "Aceptar todas",
+    "reject": "Solo esenciales",
+    "privacyLink": "Política de cookies",
+    "settings": "Configuración de cookies"
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -35,7 +35,7 @@ function getUnauthorizedResponse(): NextResponse {
  *
  * Next.js reads the nonce from the CSP response header and auto-applies it
  * to every inline script it injects (hydration, flight data) and to all
- * `next/script` components (GTM, Cookiebot). No manual nonce passing needed.
+ * `next/script` components. No manual nonce passing needed.
  *
  * Staging uses Content-Security-Policy-Report-Only so violations are logged
  * to the console without breaking the page — useful for testing CSP changes

--- a/src/types/gtm.d.ts
+++ b/src/types/gtm.d.ts
@@ -1,13 +1,9 @@
-type DataLayerEvent = {
-  event: string;
-  label?: string;
-  location?: string;
-  leadSource?: string;
-};
-
 declare global {
   interface Window {
-    dataLayer: DataLayerEvent[];
+    // biome-ignore lint/suspicious/noExplicitAny: GTM dataLayer accepts mixed entry types (event objects and gtag argument arrays)
+    dataLayer: any[];
+    // biome-ignore lint/suspicious/noExplicitAny: gtag accepts arbitrary argument arrays
+    gtag: (...args: any[]) => void;
   }
 }
 


### PR DESCRIPTION
## Summary

Replace Cookiebot (never configured) with a custom GDPR-compliant cookie consent banner and Google Tag Manager integration with Consent Mode v2.

### What changed
- **Cookie banner** (`CookieBanner.tsx`): slide-up animation, accept/reject buttons, cookie icon, privacy policy link, ARIA dialog, exit animation, reopen via footer link
- **GTM with Consent Mode v2** (`GoogleTagManager.tsx`): inline consent defaults (all denied), cookie check for returning visitors, `consent update` before GTM loads, GTM script with `afterInteractive`
- **Cookie settings link** (`CookieSettingsLink.tsx`): footer button to reopen banner via custom event
- **CSP updates**: removed Cookiebot origins, added GTM debug badge styles/fonts, fixed `font-src` to collect from service definitions
- **Privacy policy**: removed Cookiebot from data recipients, updated cookie section text
- **i18n**: added CookieBanner translations in `es.json` and `ca.json`
- **Hydration fix**: added `suppressHydrationWarning` on root `<html>` for Tag Assistant extension

### GTM setup required
After merge, configure in GTM:
1. GA4 Configuration tag → trigger **Initialization - All Pages** + **Require additional consent** → `analytics_storage` + second trigger Custom Event `consent_granted`
2. GA4 Event tags → consent requirement → `analytics_storage` individually
3. Publish container after verification